### PR TITLE
chore: sync with rhiza template v0.10.9

### DIFF
--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Configure git auth for private packages
         uses: ./.github/actions/configure-git-auth

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Configure git auth for private packages
         uses: ./.github/actions/configure-git-auth
@@ -77,9 +77,18 @@ jobs:
           lfs: true
 
       - name: Install uv
+        id: install-uv
+        continue-on-error: true
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
+          python-version: ${{ matrix.python-version }}
+
+      - name: Retry uv installation
+        if: steps.install-uv.outcome == 'failure'
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "0.11.16"
           python-version: ${{ matrix.python-version }}
 
       - name: Configure git auth for private packages
@@ -112,7 +121,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Configure git auth for private packages
         uses: ./.github/actions/configure-git-auth
@@ -136,7 +145,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Configure git auth for private packages
         uses: ./.github/actions/configure-git-auth
@@ -179,7 +188,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Configure git auth for private packages
         uses: ./.github/actions/configure-git-auth
@@ -204,7 +213,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Configure git auth for private packages
         uses: ./.github/actions/configure-git-auth
@@ -226,7 +235,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Configure git auth for private packages
         uses: ./.github/actions/configure-git-auth
@@ -248,7 +257,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Configure git auth for private packages
         uses: ./.github/actions/configure-git-auth

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -10,9 +10,10 @@
 #   2. 🏗️ Build - Build Python package with Hatch (if [build-system] is defined in pyproject.toml)
 #   3. 📦 Generate SBOM - Create Software Bill of Materials (CycloneDX format)
 #   4. 📝 Draft Release - Create draft GitHub release with build artifacts and SBOM
-#   5. 🚀 Publish to PyPI - Publish package using OIDC or custom feed
-#   6. 🐳 Publish Devcontainer - Build and publish devcontainer image (conditional)
-#   7. ✅ Finalize Release - Publish the GitHub release with links
+#   5. 📄 Update CHANGELOG - Generate and commit CHANGELOG.md to the default branch
+#   6. 🚀 Publish to PyPI - Publish package using OIDC or custom feed
+#   7. 🐳 Publish Devcontainer - Build and publish devcontainer image (conditional)
+#   8. ✅ Finalize Release - Publish the GitHub release with links
 #
 # 📦 SBOM Generation:
 #   - Generated using CycloneDX format (industry standard for software supply chain security)
@@ -122,7 +123,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Configure git auth for private packages
         uses: ./.github/actions/configure-git-auth
@@ -251,6 +252,34 @@ jobs:
           draft: true
           allowUpdates: true
           artifacts: "sbom/*"
+
+  update-changelog:
+    name: Update CHANGELOG.md
+    runs-on: ubuntu-latest
+    needs: [tag, draft-release]
+    steps:
+      - name: Checkout Default Branch
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Generate CHANGELOG.md with git-cliff
+        run: uvx git-cliff --output CHANGELOG.md
+
+      - name: Commit and push CHANGELOG.md
+        env:
+          TAG: ${{ needs.tag.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --staged --quiet || git commit -m "chore: update CHANGELOG.md for $TAG [skip ci]"
+          git push origin ${{ github.event.repository.default_branch }}
 
   # Decide at step-level whether to publish
   pypi:
@@ -403,7 +432,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: "Sync the virtual environment for ${{ github.repository }}"
         shell: bash

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Configure git auth for private packages
         uses: ./.github/actions/configure-git-auth
@@ -73,7 +73,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Configure git auth for private packages
         uses: ./.github/actions/configure-git-auth
@@ -95,7 +95,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.11.14"
+          version: "0.11.16"
 
       - name: Run pip-audit
         run: uvx pip-audit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         files: '(/__pycache__/|\.py[cod]$)'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.13'
+    rev: 'v0.15.14'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
@@ -59,7 +59,7 @@ repos:
         args: ["--ini", ".bandit", "--exclude", ".venv,tests,.rhiza/tests,.git,.pytest_cache"]
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.14
+    rev: 0.11.16
     hooks:
       - id: uv-lock
 
@@ -71,7 +71,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.3.3  # Use the latest release
+    rev: v0.4.0  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 788fb1ba82cda2ee669cee1ebf69fbba8a60c048
+sha: d20dd62adfdd9bfcd918fac200f5d37ed237c604
 repo: jebel-quant/rhiza
 host: github
-ref: v0.10.7
+ref: v0.10.9
 include: []
 exclude: []
 templates:
@@ -55,6 +55,7 @@ files:
 - .rhiza/tests/api/test_github_targets.py
 - .rhiza/tests/api/test_makefile_api.py
 - .rhiza/tests/api/test_makefile_targets.py
+- .rhiza/tests/api/test_release_workflow.py
 - .rhiza/tests/api/test_weekly_workflow.py
 - .rhiza/tests/conftest.py
 - .rhiza/tests/deps/test_dependency_health.py
@@ -92,5 +93,5 @@ files:
 - docs/mkdocs-base.yml
 - pytest.ini
 - ruff.toml
-synced_at: '2026-05-18T06:07:50Z'
+synced_at: '2026-05-22T10:58:04Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.10.7"
+ref: "v0.10.9"
 
 templates:
   - github

--- a/.rhiza/tests/api/test_ci_workflow.py
+++ b/.rhiza/tests/api/test_ci_workflow.py
@@ -63,3 +63,17 @@ def test_ci_os_matrix_make_target_can_be_configured(logger):
     )
     assert result.returncode == 0
     assert json.loads(result.stdout.strip()) == ["ubuntu-latest", "windows-latest"]
+
+
+def test_ci_test_job_retries_uv_install_on_failure(root):
+    """Test job must retry uv setup when the first attempt fails."""
+    workflow = _load_workflow(root)
+    steps = workflow["jobs"]["test"]["steps"]
+
+    install_step = next((step for step in steps if step.get("id") == "install-uv"), None)
+    assert install_step is not None, "Expected an install-uv step in test job"
+    assert install_step.get("continue-on-error") is True
+
+    retry_step = next((step for step in steps if step.get("name") == "Retry uv installation"), None)
+    assert retry_step is not None, "Expected a retry step for uv setup in test job"
+    assert retry_step.get("if") == "steps.install-uv.outcome == 'failure'"

--- a/.rhiza/tests/api/test_release_workflow.py
+++ b/.rhiza/tests/api/test_release_workflow.py
@@ -1,0 +1,155 @@
+"""Tests for the rhiza_release.yml workflow configuration.
+
+Validates that the release workflow is correctly defined, including the
+update-changelog job that generates and commits CHANGELOG.md on every release.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = Path(".github") / "workflows" / "rhiza_release.yml"
+EXPECTED_JOBS = {"tag", "build", "draft-release", "update-changelog", "pypi", "devcontainer", "finalise-release"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_workflow(root: Path) -> dict:
+    """Load and parse the release workflow YAML file."""
+    workflow_file = root / WORKFLOW_PATH
+    if not workflow_file.exists():
+        pytest.fail(f"Workflow file not found: {workflow_file}")
+    with open(workflow_file) as fh:
+        return yaml.safe_load(fh)
+
+
+def _step_commands(job: dict) -> list[str]:
+    """Return all ``run`` strings from a job's steps."""
+    return [step["run"] for step in job.get("steps", []) if "run" in step]
+
+
+def _step_uses(job: dict) -> list[str]:
+    """Return all ``uses`` strings from a job's steps."""
+    return [step["uses"] for step in job.get("steps", []) if "uses" in step]
+
+
+# ---------------------------------------------------------------------------
+# Structure tests — validate the YAML content of rhiza_release.yml
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseWorkflowStructure:
+    """Validate the static content of rhiza_release.yml."""
+
+    @pytest.fixture(scope="class")
+    def workflow(self, root):
+        """Load and return the parsed release workflow YAML."""
+        return _load_workflow(root)
+
+    def test_workflow_file_exists(self, root):
+        """Workflow file must exist at the expected path."""
+        assert (root / WORKFLOW_PATH).exists()
+
+    def test_workflow_triggers_on_version_tags(self, workflow):
+        """Workflow must trigger on version tags (v*)."""
+        triggers = workflow.get("on") or workflow.get(True) or {}
+        push = triggers.get("push", {})
+        tags = push.get("tags", [])
+        assert any("v*" in tag for tag in tags), "Workflow must trigger on v* tags"
+
+    def test_workflow_defines_all_expected_jobs(self, workflow):
+        """Workflow must define all expected jobs including update-changelog."""
+        defined_jobs = set(workflow["jobs"].keys())
+        for job in EXPECTED_JOBS:
+            assert job in defined_jobs, f"Job '{job}' not found in workflow"
+
+    def test_workflow_has_contents_write_permission(self, workflow):
+        """Workflow must have contents: write permission to push CHANGELOG.md."""
+        permissions = workflow.get("permissions", {})
+        assert permissions.get("contents") == "write", "Workflow must have contents: write permission"
+
+
+class TestUpdateChangelogJob:
+    """Validate the update-changelog job in the release workflow."""
+
+    @pytest.fixture(scope="class")
+    def workflow(self, root):
+        """Load and return the parsed release workflow YAML."""
+        return _load_workflow(root)
+
+    @pytest.fixture(scope="class")
+    def job(self, workflow):
+        """Return the update-changelog job definition."""
+        assert "update-changelog" in workflow["jobs"], "update-changelog job must exist"
+        return workflow["jobs"]["update-changelog"]
+
+    def test_update_changelog_job_exists(self, workflow):
+        """update-changelog job must be present in the workflow."""
+        assert "update-changelog" in workflow["jobs"]
+
+    def test_update_changelog_needs_draft_release(self, job):
+        """update-changelog must depend on draft-release to ensure notes are ready."""
+        needs = job.get("needs", [])
+        if isinstance(needs, str):
+            needs = [needs]
+        assert "draft-release" in needs, "update-changelog must depend on draft-release"
+
+    def test_update_changelog_needs_tag(self, job):
+        """update-changelog must depend on tag to access the tag output."""
+        needs = job.get("needs", [])
+        if isinstance(needs, str):
+            needs = [needs]
+        assert "tag" in needs, "update-changelog must depend on tag"
+
+    def test_update_changelog_runs_on_ubuntu(self, job):
+        """update-changelog must run on ubuntu-latest."""
+        assert job.get("runs-on") == "ubuntu-latest"
+
+    def test_update_changelog_checks_out_default_branch(self, job):
+        """update-changelog must checkout the default branch, not the tag."""
+        steps = job.get("steps", [])
+        checkout_steps = [s for s in steps if "uses" in s and "actions/checkout" in s["uses"]]
+        assert checkout_steps, "update-changelog must have a checkout step"
+        checkout = checkout_steps[0]
+        ref = checkout.get("with", {}).get("ref", "")
+        assert "default_branch" in ref, "update-changelog must checkout the default branch"
+
+    def test_update_changelog_uses_full_git_history(self, job):
+        """update-changelog checkout must fetch full history (fetch-depth: 0) for git-cliff."""
+        steps = job.get("steps", [])
+        checkout_steps = [s for s in steps if "uses" in s and "actions/checkout" in s["uses"]]
+        assert checkout_steps, "update-changelog must have a checkout step"
+        checkout = checkout_steps[0]
+        fetch_depth = checkout.get("with", {}).get("fetch-depth")
+        assert fetch_depth == 0, "update-changelog checkout must use fetch-depth: 0"
+
+    def test_update_changelog_generates_changelog_with_git_cliff(self, job):
+        """update-changelog must run git-cliff to generate CHANGELOG.md."""
+        cmds = _step_commands(job)
+        assert any("git-cliff" in cmd and "CHANGELOG.md" in cmd for cmd in cmds), (
+            "update-changelog must run git-cliff to generate CHANGELOG.md"
+        )
+
+    def test_update_changelog_commits_and_pushes(self, job):
+        """update-changelog must commit and push CHANGELOG.md."""
+        cmds = _step_commands(job)
+        push_cmds = [cmd for cmd in cmds if "git push" in cmd]
+        assert push_cmds, "update-changelog must push CHANGELOG.md to the repository"
+
+    def test_update_changelog_configures_git_identity(self, job):
+        """update-changelog must configure git user identity for the commit."""
+        cmds = _step_commands(job)
+        identity_cmds = [cmd for cmd in cmds if "git config user" in cmd]
+        assert identity_cmds, "update-changelog must configure git user identity"
+
+    def test_update_changelog_skips_commit_when_no_changes(self, job):
+        """update-changelog must skip commit when CHANGELOG.md has not changed."""
+        cmds = _step_commands(job)
+        idempotent = any("git diff --staged --quiet" in cmd for cmd in cmds)
+        assert idempotent, "update-changelog must check for staged changes before committing to be idempotent"


### PR DESCRIPTION
## Summary

- Bumped rhiza template version from `v0.10.7` to `v0.10.9` in `.rhiza/template.yml`
- Ran `make sync` — all changes applied cleanly (no conflicts)
- Updated GitHub Actions workflows: `rhiza_book.yml`, `rhiza_ci.yml`, `rhiza_release.yml`, `rhiza_weekly.yml`
- Updated `.pre-commit-config.yaml`
- Updated `.rhiza/tests/api/test_ci_workflow.py`
- Added new `.rhiza/tests/api/test_release_workflow.py`

## Test plan

- [ ] CI passes on this branch
- [ ] Workflow files behave as expected (note: updating workflow files requires a token with the `workflow` permission in GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)