### PR TITLE
fix: bump rhiza_benchmark.yml reference from v0.16.0 to v0.18.4

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.16.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.18.4
     secrets: inherit


### PR DESCRIPTION
## Summary
- `rhiza_benchmark.yml@v0.16.0` doesn't exist (added in v0.18.0), causing CI failure
- Updated to `@v0.18.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)