### PR TITLE
fix: stop bump/release from publishing an older version (#1126)

### DIFF
--- a/src/rhiza_tools/cli.py
+++ b/src/rhiza_tools/cli.py
@@ -232,6 +232,11 @@ def release(
     language: str | None = typer.Option(
         None, "--language", "-l", help="Programming language (python or go). Auto-detected if not specified."
     ),
+    allow_older: bool = typer.Option(
+        False,
+        "--allow-older",
+        help="Allow releasing a version not newer than the latest remote release (maintenance/back-branch).",
+    ),
     config: Path | None = CONFIG_OPTION,
     verbose: bool = VERBOSE_OPTION,
 ) -> None:
@@ -250,6 +255,7 @@ def release(
         dry_run: If True, show what would happen without actually pushing the tag.
         non_interactive: If True, skip all confirmation prompts (useful for CI/CD).
         language: Programming language (python or go). Auto-detected if not specified.
+        allow_older: If True, allow releasing a version not newer than the latest remote release.
         config: Path to the .cfg.toml bumpversion config file. Passed through to bump when --with-bump is used.
         verbose: If True, enable verbose debug output.
 
@@ -294,7 +300,7 @@ def release(
             console.error("Supported languages: python, go")
             raise typer.Exit(code=1) from None
 
-    release_command(bump, push, dry_run, non_interactive, with_bump, lang_enum, config)
+    release_command(bump, push, dry_run, non_interactive, with_bump, lang_enum, config, allow_older)
 
 
 @app.command()

--- a/src/rhiza_tools/commands/_shared.py
+++ b/src/rhiza_tools/commands/_shared.py
@@ -8,6 +8,7 @@ Utilities:
     - run_git_command: Execute git commands with standard error handling
     - get_current_version: Read the project version from pyproject.toml
     - get_current_git_branch: Safely determine the current git branch
+    - get_latest_remote_version: Highest semver tag published on the remote
     - validate_pyproject_exists: Guard against missing pyproject.toml
 """
 
@@ -16,6 +17,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import questionary as qs
+import semver
 import tomlkit
 import typer
 
@@ -111,6 +113,54 @@ def get_current_git_branch() -> str:
     """
     result = run_git_command(["git", "rev-parse", "--abbrev-ref", "HEAD"], check=False)
     return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def get_latest_remote_version(remote: str = "origin") -> semver.Version | None:
+    """Return the highest semantic-version tag published on *remote*.
+
+    This reads ``v*``-style tags directly from the remote with ``git ls-remote``
+    (no local fetch, no working-tree changes) and returns the greatest valid
+    semver among them. It is the source of truth for "what is the latest
+    released version" and exists to stop the release tooling from trusting a
+    potentially stale local ``pyproject.toml`` (see issue #1126).
+
+    Tags that are not valid semantic versions are ignored. The function never
+    raises for the common failure modes (no remote configured, no tags, network
+    unavailable); it returns ``None`` so callers can degrade gracefully.
+
+    Args:
+        remote: The git remote to query. Defaults to ``"origin"``.
+
+    Returns:
+        The highest :class:`semver.Version` found on the remote, or ``None`` if
+        the remote cannot be reached or has no valid version tags.
+
+    Example:
+        >>> latest = get_latest_remote_version()  # doctest: +SKIP
+        >>> print(latest)  # doctest: +SKIP
+        0.4.0
+    """
+    result = run_git_command(["git", "ls-remote", "--tags", remote], check=False)
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+
+    versions: list[semver.Version] = []
+    for line in result.stdout.splitlines():
+        # Each line is "<sha>\trefs/tags/<tag>"; annotated tags also appear
+        # peeled as "refs/tags/<tag>^{}" which we normalise away.
+        ref = line.split("\t")[-1].strip()
+        if not ref.startswith("refs/tags/"):
+            continue
+        tag = ref[len("refs/tags/") :].removesuffix("^{}")
+        if tag.startswith("v"):
+            tag = tag[1:]
+        try:
+            versions.append(semver.Version.parse(tag))
+        except ValueError:
+            # Non-semver tags (e.g. "latest", date stamps) are not releases.
+            continue
+
+    return max(versions) if versions else None
 
 
 def validate_pyproject_exists() -> None:

--- a/src/rhiza_tools/commands/bump.py
+++ b/src/rhiza_tools/commands/bump.py
@@ -35,7 +35,13 @@ from bumpversion.ui import setup_logging
 from loguru import logger
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import COOL_STYLE, NON_INTERACTIVE_ERRORS, get_current_git_branch, run_git_command
+from rhiza_tools.commands._shared import (
+    COOL_STYLE,
+    NON_INTERACTIVE_ERRORS,
+    get_current_git_branch,
+    get_latest_remote_version,
+    run_git_command,
+)
 from rhiza_tools.config import CONFIG_FILENAME
 
 
@@ -830,6 +836,43 @@ def _restore_original_branch(original_branch: str | None, dry_run: bool) -> None
         run_git_command(["git", "checkout", original_branch], check=False)
 
 
+def _resolve_bump_baseline(current_version_str: str) -> str:
+    """Return the version to bump *from*, never lower than the latest remote tag.
+
+    The local ``pyproject.toml`` can be stale (a branch that diverged before the
+    previous release was merged), which historically caused relative bumps to
+    generate already-released version numbers (issue #1126). When the highest
+    semver tag on the remote is newer than the local version, that remote
+    version is used as the baseline instead and the discrepancy is reported.
+
+    The remote is queried best-effort: if it cannot be reached (offline, no
+    remote configured) the local version is used unchanged.
+
+    Args:
+        current_version_str: The version read from the local project files.
+
+    Returns:
+        The version string to use as the basis for relative bumps.
+    """
+    latest_remote = get_latest_remote_version()
+    if latest_remote is None:
+        return current_version_str
+
+    try:
+        local_version = semver.Version.parse(current_version_str)
+    except ValueError:
+        local_version = None
+
+    if local_version is None or latest_remote > local_version:
+        console.warning(
+            f"Local version {current_version_str} is behind the latest remote tag v{latest_remote}; "
+            f"bumping from v{latest_remote} instead to avoid releasing an older version."
+        )
+        return str(latest_remote)
+
+    return current_version_str
+
+
 def bump_command(options: BumpOptions) -> None:
     """Bump version using bump-my-version.
 
@@ -901,11 +944,18 @@ def bump_command(options: BumpOptions) -> None:
     console.info(f"Current branch: {typer.style(current_git_branch, fg=typer.colors.CYAN, bold=True)}")
     console.info(f"Current version: {typer.style(current_version_str, fg=typer.colors.CYAN, bold=True)}")
 
+    # Reconcile the bump baseline with the remote so a stale local pyproject.toml
+    # (e.g. a branch that diverged before the previous release merged) cannot
+    # produce a version lower than what is already published (issue #1126).
+    # Explicit target versions are honoured as-is; only relative bumps
+    # (patch/minor/major/prerelease) follow the remote-aware baseline.
+    bump_baseline = _resolve_bump_baseline(current_version_str)
+
     # Determine new version string
     if options.version:
-        new_version_str = _parse_version_argument(options.version, current_version_str)
+        new_version_str = _parse_version_argument(options.version, bump_baseline)
     else:
-        new_version_str = get_interactive_bump_type(current_version_str)
+        new_version_str = get_interactive_bump_type(bump_baseline)
 
     console.info(f"New version will be: {typer.style(new_version_str, fg=typer.colors.GREEN, bold=True)}")
 

--- a/src/rhiza_tools/commands/release.py
+++ b/src/rhiza_tools/commands/release.py
@@ -31,11 +31,13 @@ from loguru import logger
 from rhiza_tools import console
 from rhiza_tools.commands._shared import (
     NON_INTERACTIVE_ERRORS,
+    get_latest_remote_version,
     run_git_command,
 )
 from rhiza_tools.commands.bump import (
     BumpOptions,
     Language,
+    _resolve_bump_baseline,
     bump_command,
     get_bumped_version_from_type,
     get_current_version,
@@ -276,7 +278,7 @@ def _resolve_explicit_bump_type(bump_type: str, language: Language) -> tuple[boo
     Raises:
         typer.Exit: If the current version is invalid or the bump type is unsupported.
     """
-    current_version_str = get_current_version(language)
+    current_version_str = _resolve_bump_baseline(get_current_version(language))
     try:
         current_semver = semver.Version.parse(current_version_str)
     except ValueError:
@@ -303,11 +305,11 @@ def _resolve_with_bump_flag(non_interactive: bool, language: Language) -> tuple[
     """
     if non_interactive:
         console.warning("--with-bump in non-interactive mode without --bump type, defaulting to patch")
-        current_version_str = get_current_version(language)
+        current_version_str = _resolve_bump_baseline(get_current_version(language))
         current_semver = semver.Version.parse(current_version_str)
         return True, str(current_semver.bump_patch())
 
-    current_version_str = get_current_version(language)
+    current_version_str = _resolve_bump_baseline(get_current_version(language))
     try:
         new_version = get_interactive_bump_type(current_version_str)
     except _EXIT_OR_NON_INTERACTIVE:
@@ -338,7 +340,7 @@ def _resolve_interactive_prompt(language: Language) -> tuple[bool, str | None]:
     if not should_bump:
         return False, None
 
-    current_version_str = get_current_version(language)
+    current_version_str = _resolve_bump_baseline(get_current_version(language))
     try:
         new_version = get_interactive_bump_type(current_version_str)
     except _EXIT_OR_NON_INTERACTIVE:
@@ -558,6 +560,59 @@ def _handle_tag_validation(dry_run: bool, bumped_new_version: str | None, tag: s
         _validate_tag_state(tag, current_version)
 
 
+def _check_release_version_monotonic(version_str: str, allow_older: bool) -> None:
+    """Ensure the version being released is newer than the latest remote release.
+
+    This is the authoritative guard against issue #1126: it refuses to push a
+    tag whose version is not strictly greater than the highest version already
+    published on the remote, regardless of what the (possibly stale) local
+    ``pyproject.toml`` says.
+
+    When the remote has no published version tags (first release) or cannot be
+    reached, the check is skipped so normal first releases and offline dry-runs
+    still work.
+
+    Args:
+        version_str: The version that is about to be released (with or without a
+            leading ``v``).
+        allow_older: If True, downgrade the hard error to a warning so that
+            intentional maintenance / back-branch releases can proceed.
+
+    Raises:
+        typer.Exit: If the version is not newer than the latest remote release
+            and ``allow_older`` is False.
+    """
+    latest_remote = get_latest_remote_version()
+    if latest_remote is None:
+        return
+
+    try:
+        candidate = semver.Version.parse(version_str[1:] if version_str.startswith("v") else version_str)
+    except ValueError:
+        console.error(f"Invalid semantic version: {version_str}")
+        raise typer.Exit(code=1) from None
+
+    if candidate > latest_remote:
+        console.success(f"Preflight: v{candidate} is newer than the latest remote release v{latest_remote}")
+        return
+
+    relation = "the same as" if candidate == latest_remote else "older than"
+    if allow_older:
+        console.warning(
+            f"Version v{candidate} is {relation} the latest remote release v{latest_remote}; "
+            "proceeding because --allow-older was set."
+        )
+        return
+
+    console.error(f"Refusing to release v{candidate}: it is {relation} the latest remote release v{latest_remote}.")
+    console.error("Your branch likely diverged before a newer release was merged (issue #1126).")
+    console.error("To resolve:")
+    console.error("  Sync with the latest release, e.g.:  git pull --rebase origin <default-branch>")
+    console.error(f"  Then bump again so the new version is higher than v{latest_remote}.")
+    console.error("For an intentional maintenance/back-branch release, re-run with --allow-older.")
+    raise typer.Exit(code=1)
+
+
 def release_command(
     bump_type: str | None = None,
     push: bool = False,
@@ -566,6 +621,7 @@ def release_command(
     with_bump: bool = False,
     language: Language | None = None,
     config: Path | None = None,
+    allow_older: bool = False,
 ) -> None:
     """Push a release tag to remote.
 
@@ -585,6 +641,9 @@ def release_command(
         with_bump: If True, enable interactive bump selection (works with dry-run).
         language: Programming language (python or go). Auto-detected if not specified.
         config: Optional path to the .cfg.toml bumpversion config file.
+        allow_older: If True, permit releasing a version that is not strictly
+            greater than the latest version already published on the remote.
+            Required for intentional back-branch / maintenance releases.
 
     Raises:
         typer.Exit: If no supported project files are found, repository is not clean,
@@ -640,6 +699,12 @@ def release_command(
     # ── Preflight validation: check everything BEFORE making any changes ──
     default_branch = get_default_branch()
     _check_repository_state(dry_run, current_branch, default_branch)
+
+    # Ensure the version we are about to release is strictly newer than the
+    # latest version already published on the remote (issue #1126). Runs in all
+    # modes (including dry-run) and before any mutation.
+    prospective_version = new_version if (should_bump and new_version) else get_current_version(language)
+    _check_release_version_monotonic(prospective_version, allow_older)
 
     # If bumping, pre-validate that the new tag won't conflict with remote
     if should_bump and new_version and not dry_run:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,22 @@ import pytest
 GIT = shutil.which("git") or "git"
 
 
+@pytest.fixture(autouse=True)
+def _no_remote_version(monkeypatch):
+    """Stub remote-version lookups so tests never hit the network.
+
+    ``get_latest_remote_version`` shells out to ``git ls-remote`` against the
+    real ``origin``. Defaulting it to ``None`` keeps the suite hermetic and
+    preserves pre-existing behaviour (bump baseline = local version, release
+    monotonicity guard skipped). Tests that exercise the remote-aware paths
+    override these with ``monkeypatch.setattr`` to return a specific version.
+    """
+    from rhiza_tools.commands import bump, release
+
+    for module in (bump, release):
+        monkeypatch.setattr(module, "get_latest_remote_version", lambda *args, **kwargs: None)
+
+
 @pytest.fixture
 def temp_project(tmp_path, monkeypatch):
     """Create a temporary project directory with git and pyproject.toml.

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -62,29 +62,29 @@ def test_release_command(monkeypatch):
 
     result = runner.invoke(app, ["release", "--dry-run"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config)
-    mock_release_command.assert_called_once_with(None, False, True, False, False, None, None)
+    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
+    mock_release_command.assert_called_once_with(None, False, True, False, False, None, None, False)
 
     mock_release_command.reset_mock()
 
     result = runner.invoke(app, ["release"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config)
-    mock_release_command.assert_called_once_with(None, False, False, False, False, None, None)
+    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
+    mock_release_command.assert_called_once_with(None, False, False, False, False, None, None, False)
 
     mock_release_command.reset_mock()
 
     result = runner.invoke(app, ["release", "--non-interactive"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config)
-    mock_release_command.assert_called_once_with(None, False, False, True, False, None, None)
+    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
+    mock_release_command.assert_called_once_with(None, False, False, True, False, None, None, False)
 
     mock_release_command.reset_mock()
 
     result = runner.invoke(app, ["release", "--with-bump", "--push", "--dry-run"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config)
-    mock_release_command.assert_called_once_with(None, True, True, False, True, None, None)
+    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
+    mock_release_command.assert_called_once_with(None, True, True, False, True, None, None, False)
 
     mock_release_command.reset_mock()
 
@@ -92,8 +92,8 @@ def test_release_command(monkeypatch):
 
     result = runner.invoke(app, ["release", "--language", "go", "--dry-run"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config)
-    mock_release_command.assert_called_once_with(None, False, True, False, False, Language.GO, None)
+    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
+    mock_release_command.assert_called_once_with(None, False, True, False, False, Language.GO, None, False)
 
     mock_release_command.reset_mock()
 
@@ -108,8 +108,10 @@ def test_release_command(monkeypatch):
 
     result = runner.invoke(app, ["release", "--config", "/custom/.cfg.toml", "--dry-run"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config)
-    mock_release_command.assert_called_once_with(None, False, True, False, False, None, Path("/custom/.cfg.toml"))
+    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
+    mock_release_command.assert_called_once_with(
+        None, False, True, False, False, None, Path("/custom/.cfg.toml"), False
+    )
 
 
 def test_update_readme(monkeypatch):

--- a/tests/test_e2e_bump_release.py
+++ b/tests/test_e2e_bump_release.py
@@ -925,7 +925,7 @@ class TestCLIIntegration:
 
         result = runner.invoke(app, ["release", "--with-bump", "--push", "--dry-run"])
         assert result.exit_code == 0
-        mock_release.assert_called_once_with(None, True, True, False, True, None, None)
+        mock_release.assert_called_once_with(None, True, True, False, True, None, None, False)
 
     def test_release_bump_and_with_bump_cli(self, monkeypatch):
         """Test --bump MINOR --with-bump together via CLI."""
@@ -939,7 +939,7 @@ class TestCLIIntegration:
 
         result = runner.invoke(app, ["release", "--bump", "MINOR", "--with-bump", "--push"])
         assert result.exit_code == 0
-        mock_release.assert_called_once_with("MINOR", True, False, False, True, None, None)
+        mock_release.assert_called_once_with("MINOR", True, False, False, True, None, None, False)
 
     def test_bump_cli_all_flags(self, monkeypatch):
         """Test bump CLI with all flags."""

--- a/tests/test_versioning_guard_1126.py
+++ b/tests/test_versioning_guard_1126.py
@@ -1,0 +1,205 @@
+"""Regression tests for issue #1126: releasing an older version.
+
+These cover the three layers of the fix:
+
+* ``get_latest_remote_version`` — read the highest semver tag from the remote.
+* ``_resolve_bump_baseline`` / ``bump_command`` — never bump from a stale local
+  version that is behind the remote.
+* ``_check_release_version_monotonic`` / ``release_command`` — refuse to release
+  a version that is not strictly newer than the latest remote release, unless
+  ``--allow-older`` is given.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import semver
+import typer
+
+from rhiza_tools.commands import bump as bump_mod
+from rhiza_tools.commands import release as release_mod
+from rhiza_tools.commands._shared import get_latest_remote_version
+from rhiza_tools.commands.bump import BumpOptions, Language, _resolve_bump_baseline, bump_command, get_current_version
+
+_BUMPVERSION_CFG = """
+[tool.bumpversion]
+parse = "(?P<major>\\\\d+)\\\\.(?P<minor>\\\\d+)\\\\.(?P<patch>\\\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_version = false
+tag = false
+commit = false
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+"""
+
+
+@pytest.fixture
+def bump_project(temp_project):
+    """A project with a minimal bumpversion config (self-contained for this module)."""
+    rhiza_dir = temp_project / ".rhiza"
+    rhiza_dir.mkdir(exist_ok=True)
+    (rhiza_dir / ".cfg.toml").write_text(_BUMPVERSION_CFG)
+    return temp_project
+
+
+def _ls_remote(*tags: str) -> MagicMock:
+    """Build a fake ``git ls-remote --tags`` CompletedProcess for *tags*."""
+    lines = "\n".join(f"0000000000000000000000000000000000000000\trefs/tags/{t}" for t in tags)
+    return MagicMock(returncode=0, stdout=lines + "\n")
+
+
+# ── get_latest_remote_version ─────────────────────────────────────────────────
+
+
+def test_latest_remote_version_picks_highest():
+    """The highest semver tag wins, regardless of listing order."""
+    with patch(
+        "rhiza_tools.commands._shared.run_git_command",
+        return_value=_ls_remote("v0.3.2", "v0.10.0", "v0.4.0"),
+    ):
+        assert get_latest_remote_version() == semver.Version.parse("0.10.0")
+
+
+def test_latest_remote_version_ignores_non_semver_and_peeled_refs():
+    """Non-semver tags and peeled ``^{}`` duplicates are ignored, not fatal."""
+    listing = MagicMock(
+        returncode=0,
+        stdout=(
+            "sha\trefs/tags/v1.0.0\n"
+            "sha\trefs/tags/v1.0.0^{}\n"  # peeled duplicate of an annotated tag
+            "sha\trefs/tags/latest\n"  # not a version
+            "sha\trefs/heads/main\n"  # not a tag at all
+        ),
+    )
+    with patch("rhiza_tools.commands._shared.run_git_command", return_value=listing):
+        assert get_latest_remote_version() == semver.Version.parse("1.0.0")
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        MagicMock(returncode=128, stdout=""),  # no remote / network error
+        MagicMock(returncode=0, stdout="   \n"),  # remote reachable but no tags
+    ],
+)
+def test_latest_remote_version_returns_none_when_unavailable(result):
+    """Degrade gracefully to None when the remote can't be read or has no tags."""
+    with patch("rhiza_tools.commands._shared.run_git_command", return_value=result):
+        assert get_latest_remote_version() is None
+
+
+# ── _resolve_bump_baseline ────────────────────────────────────────────────────
+
+
+def test_baseline_uses_remote_when_local_is_stale(monkeypatch):
+    """The exact #1126 scenario: local 0.3.2, remote 0.4.0 -> bump from 0.4.0."""
+    monkeypatch.setattr(bump_mod, "get_latest_remote_version", lambda *a, **k: semver.Version.parse("0.4.0"))
+    assert _resolve_bump_baseline("0.3.2") == "0.4.0"
+
+
+def test_baseline_keeps_local_when_ahead_of_remote(monkeypatch):
+    """A local version newer than the remote is kept as the baseline."""
+    monkeypatch.setattr(bump_mod, "get_latest_remote_version", lambda *a, **k: semver.Version.parse("0.4.0"))
+    assert _resolve_bump_baseline("0.5.0") == "0.5.0"
+
+
+def test_baseline_falls_back_to_local_when_remote_unknown(monkeypatch):
+    """Offline / no remote -> use the local version unchanged (autouse stub)."""
+    assert _resolve_bump_baseline("0.3.2") == "0.3.2"
+
+
+def test_bump_patch_from_stale_branch_jumps_past_remote(bump_project, monkeypatch):
+    """End-to-end: `bump patch` on a stale 0.3.2 branch yields 0.4.1, not 0.3.3."""
+    pyproject = bump_project / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "test-project"\nversion = "0.3.2"\n')
+    monkeypatch.setattr(bump_mod, "get_latest_remote_version", lambda *a, **k: semver.Version.parse("0.4.0"))
+
+    bump_command(BumpOptions(version="patch"))
+
+    assert get_current_version(Language.PYTHON) == "0.4.1"
+
+
+# ── _check_release_version_monotonic ──────────────────────────────────────────
+
+
+def _patch_remote_latest(monkeypatch, version: str | None):
+    monkeypatch.setattr(
+        release_mod,
+        "get_latest_remote_version",
+        lambda *a, **k: semver.Version.parse(version) if version else None,
+    )
+
+
+def test_monotonic_allows_newer(monkeypatch):
+    """A strictly newer version passes the guard."""
+    _patch_remote_latest(monkeypatch, "0.4.0")
+    release_mod._check_release_version_monotonic("0.4.1", allow_older=False)  # no raise
+
+
+@pytest.mark.parametrize("candidate", ["0.3.4", "0.4.0"])
+def test_monotonic_blocks_older_or_equal(monkeypatch, candidate):
+    """Older or equal versions are rejected without --allow-older."""
+    _patch_remote_latest(monkeypatch, "0.4.0")
+    with pytest.raises(typer.Exit):
+        release_mod._check_release_version_monotonic(candidate, allow_older=False)
+
+
+def test_monotonic_allow_older_override(monkeypatch):
+    """--allow-older downgrades the block to a warning (maintenance release)."""
+    _patch_remote_latest(monkeypatch, "0.4.0")
+    release_mod._check_release_version_monotonic("0.3.4", allow_older=True)  # no raise
+
+
+def test_monotonic_skipped_when_no_remote_tags(monkeypatch):
+    """First release (no remote tags) is always allowed."""
+    _patch_remote_latest(monkeypatch, None)
+    release_mod._check_release_version_monotonic("0.1.0", allow_older=False)  # no raise
+
+
+# ── release_command integration ───────────────────────────────────────────────
+
+
+def _release_git_mock():
+    """Minimal git mock sufficient to reach the monotonicity guard in dry-run."""
+
+    def mock_run_git_command(cmd, check=True):
+        result = MagicMock(returncode=0, stdout="")
+        if "rev-parse" in cmd and "--abbrev-ref" in cmd:
+            result.stdout = "feature/diverged"
+        elif "remote" in cmd and "show" in cmd:
+            result.stdout = "* remote origin\n  HEAD branch: main\n"
+        elif "ls-remote" in cmd:
+            result.returncode = 1  # tag does not exist on remote
+        return result
+
+    return mock_run_git_command
+
+
+def test_release_blocks_stale_version(tmp_path, monkeypatch):
+    """Release on a stale 0.3.2 checkout is blocked when remote already has 0.4.0."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "p"\nversion = "0.3.2"\n')
+    monkeypatch.chdir(tmp_path)
+    _patch_remote_latest(monkeypatch, "0.4.0")
+
+    with (
+        patch("rhiza_tools.commands.release.run_git_command", side_effect=_release_git_mock()),
+        pytest.raises(typer.Exit),
+    ):
+        release_mod.release_command(non_interactive=True, dry_run=True)
+
+
+def test_release_allows_stale_version_with_override(tmp_path, monkeypatch):
+    """--allow-older lets the same stale release through (back-branch maintenance)."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "p"\nversion = "0.3.2"\n')
+    monkeypatch.chdir(tmp_path)
+    _patch_remote_latest(monkeypatch, "0.4.0")
+
+    with patch("rhiza_tools.commands.release.run_git_command", side_effect=_release_git_mock()):
+        # Should complete the dry-run without raising for the monotonicity guard.
+        release_mod.release_command(non_interactive=True, dry_run=True, allow_older=True)


### PR DESCRIPTION
## Problem

Reported in jebel-quant/rhiza#1126. `rhiza-tools bump` reads the current version from the local `pyproject.toml`. A branch that diverged **before** a previous release was merged still carries an old version, so a relative bump generates an already-released number — e.g. a branch at `0.3.2` produces `0.3.3`/`0.3.4` even though `0.4.0` is already published. The release path only checked whether the *exact* tag already existed, never that the new version was *newer*, so the stale version went through.

## Fix

- **`get_latest_remote_version()`** (`_shared.py`): reads the highest semver tag from the remote via `git ls-remote` (read-only; degrades to `None` offline / first release).
- **`bump`**: reconciles its baseline to `max(local, remote)`, so relative bumps never start from a stale local version. Explicit versions are still honoured.
- **`release`**: refuses to push a tag that is not strictly newer than the latest remote release, with a **`--allow-older`** override for intentional maintenance / back-branch releases (strict-monotonic-with-override).

## Verification

- New regression suite `tests/test_versioning_guard_1126.py` (15 tests) covering the helper, the bump baseline, the monotonic guard, and `release_command` end to end.
- Hermetic-by-default: an autouse conftest stub keeps the suite off the network.
- Full suite: **426 passed**; ruff / ruff-format / bandit / interrogate clean.
- Reproduced and re-verified the fix end-to-end in an isolated local sandbox (a bare repo as `origin`) — `bump patch` now yields `0.4.1` instead of `0.3.3`; the guard blocks `v0.3.3` and `--allow-older` permits it.

## Companion PR

CI backstop in the release workflow so manually-pushed tags are caught too: jebel-quant/rhiza#1133.