### PR TITLE
feat(bump): fold a regenerated CHANGELOG.md into the bump commit

### DIFF
--- a/src/rhiza_tools/commands/bump.py
+++ b/src/rhiza_tools/commands/bump.py
@@ -517,6 +517,41 @@ def _build_configuration(
         return config, config_path
 
 
+def _build_changelog_hooks(new_version: str) -> list[str]:
+    """Build git-cliff pre-commit hooks that fold CHANGELOG.md into the bump commit.
+
+    bump-my-version commits whatever is staged when it runs its ``pre_commit_hooks`` —
+    the same mechanism the project config already uses to include ``uv.lock``.
+    Regenerating the changelog there means the version bump, the lockfile and the
+    changelog land in a single commit and tag, with no separate push to the default
+    branch. That separate push is undesirable: it is blocked by branch-protection
+    rulesets and counts as an unreviewed change against the OpenSSF Scorecard
+    Code-Review check.
+
+    The hooks are only emitted when the project is configured for git-cliff (a
+    ``cliff.toml`` is present), so projects without changelog tooling are unaffected.
+    The new version is passed with ``--tag`` because the release tag does not exist
+    yet when the hooks run; otherwise git-cliff would file the new entries under
+    "unreleased".
+
+    Args:
+        new_version: The version being bumped to (without a leading ``v``).
+
+    Returns:
+        The git-cliff hook commands, or an empty list when git-cliff is not configured.
+
+    Example:
+        >>> _build_changelog_hooks("1.2.3")  # doctest: +SKIP
+        ['uvx git-cliff --tag v1.2.3 --output CHANGELOG.md', 'git add CHANGELOG.md']
+    """
+    if not (Path("cliff.toml").exists() or Path(".cliff.toml").exists()):
+        return []
+    return [
+        f"uvx git-cliff --tag v{new_version} --output CHANGELOG.md",
+        "git add CHANGELOG.md",
+    ]
+
+
 def _get_files_to_modify(config: Any) -> list[Path]:
     """Get list of files that will be modified by bump-my-version.
 
@@ -980,6 +1015,13 @@ def bump_command(options: BumpOptions) -> None:
         _preflight_bump(new_version_str, config, config_path)
         # Rebuild configuration to avoid stale state from dry-run
         config, config_path = _build_configuration(current_version_str, options.allow_dirty, commit, options.config)
+
+    # When we are about to create a real commit, fold a freshly generated
+    # CHANGELOG.md into it via git-cliff (mirroring how uv.lock is included). This
+    # keeps the changelog current as part of the bump commit, avoiding a separate
+    # unreviewed push to the default branch. No-op for projects without a cliff.toml.
+    if commit and not options.dry_run:
+        config.pre_commit_hooks = list(config.pre_commit_hooks) + _build_changelog_hooks(new_version_str)
 
     _execute_bump(new_version_str, config, config_path, options.dry_run)
 

--- a/tests/test_bump_command.py
+++ b/tests/test_bump_command.py
@@ -497,6 +497,64 @@ def test_bump_with_commit_flag(bump_project, monkeypatch):
     assert called_with_params.get("commit") is True
 
 
+def test_build_changelog_hooks_returns_empty_without_cliff_config(bump_project):
+    """No changelog hooks are produced when the project has no git-cliff config."""
+    from rhiza_tools.commands.bump import _build_changelog_hooks
+
+    assert _build_changelog_hooks("1.2.3") == []
+
+
+def test_build_changelog_hooks_present_with_cliff_config(bump_project):
+    """A cliff.toml turns on git-cliff hooks that fold CHANGELOG.md into the bump commit."""
+    from pathlib import Path
+
+    from rhiza_tools.commands.bump import _build_changelog_hooks
+
+    Path("cliff.toml").write_text("[changelog]\n")
+    assert _build_changelog_hooks("1.2.3") == [
+        "uvx git-cliff --tag v1.2.3 --output CHANGELOG.md",
+        "git add CHANGELOG.md",
+    ]
+
+
+def test_bump_folds_changelog_hook_into_commit(bump_project, monkeypatch):
+    """Committing with a cliff.toml present appends the git-cliff hook to the bump commit."""
+    from pathlib import Path
+
+    Path("cliff.toml").write_text("[changelog]\n")
+
+    captured = {}
+
+    def mock_do_bump(*args, **kwargs):
+        # Capture the config used for the real (non-dry-run) bump commit.
+        if kwargs.get("dry_run") is False:
+            captured["config"] = kwargs.get("config")
+
+    monkeypatch.setattr("rhiza_tools.commands.bump.do_bump", mock_do_bump)
+
+    bump_command(BumpOptions(version="patch", commit=True))
+
+    hooks = list(captured["config"].pre_commit_hooks)
+    assert "uvx git-cliff --tag v0.1.1 --output CHANGELOG.md" in hooks
+    assert "git add CHANGELOG.md" in hooks
+
+
+def test_bump_without_cliff_config_adds_no_changelog_hook(bump_project, monkeypatch):
+    """Without a cliff.toml, committing injects no git-cliff hook."""
+    captured = {}
+
+    def mock_do_bump(*args, **kwargs):
+        if kwargs.get("dry_run") is False:
+            captured["config"] = kwargs.get("config")
+
+    monkeypatch.setattr("rhiza_tools.commands.bump.do_bump", mock_do_bump)
+
+    bump_command(BumpOptions(version="patch", commit=True))
+
+    hooks = list(captured["config"].pre_commit_hooks)
+    assert not any("git-cliff" in hook for hook in hooks)
+
+
 def test_bump_configuration_load_failure(bump_project, monkeypatch):
     """Test bump command when configuration loading fails."""
 


### PR DESCRIPTION
## What

When bumping with a commit (`make publish` / `release --with-bump`), regenerate `CHANGELOG.md` via git-cliff and stage it as a bump-my-version `pre_commit_hook`, so the **version bump, `uv.lock` and changelog land in a single commit and tag**.

## Why

Previously the changelog was regenerated and pushed to the default branch by a separate CI job *after* the release. That push is now problematic:

- A branch-protection ruleset rejects it (`GH013` — changes must go through a PR), failing the release.
- It's an unreviewed direct-to-main commit that counts against the OpenSSF Scorecard **Code-Review** check.

Folding the changelog into the bump commit (which the maintainer already creates locally) removes the separate push entirely — no bot, no token, no PR — while keeping `CHANGELOG.md` current.

## How

- New `_build_changelog_hooks(new_version)` returns `["uvx git-cliff --tag vX.Y.Z --output CHANGELOG.md", "git add CHANGELOG.md"]`.
- `--tag` is required because the release tag doesn't exist yet when the hook runs (otherwise entries land under "unreleased").
- Reuses the same `pre_commit_hooks` mechanism that already folds in `uv.lock`.
- **No-op for projects without a `cliff.toml`** — gated on its presence.

## Tests

4 new tests (helper both branches + injection with/without `cliff.toml`). Full suite: 430 passed, 99.65% coverage, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)