### PR TITLE
quality: docs gate, strict ty, 100% coverage (#209, #210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,32 @@ rhiza-tools release --bump PATCH --push --non-interactive
 *   `--dry-run` - Show what would happen without making any changes.
 *   `--non-interactive`, `-y` - Skip all confirmation prompts (for CI/CD).
 
+### `rollback`
+
+Reverse a release and/or version bump. Deletes the release tag locally and on the
+remote, and optionally reverts the version-bump commit. Uses `git revert` (not
+`git reset`), so it is safe even after the changes have been pushed.
+
+**Usage:**
+
+```bash
+# Interactive (choose from recent tags)
+rhiza-tools rollback
+
+# Preview a specific tag's rollback
+rhiza-tools rollback v1.2.3 --dry-run
+
+# Also revert the version-bump commit, no prompts (for CI/CD)
+rhiza-tools rollback v1.2.3 --revert-bump --non-interactive
+```
+
+**Options:**
+
+*   `--revert-bump` - Also revert the version-bump commit associated with the tag.
+*   `--dry-run` - Show what would happen without making any changes.
+*   `--non-interactive`, `-y` - Skip all confirmation prompts (for CI/CD).
+*   `--verbose` - Enable verbose debug output.
+
 ### `update-readme`
 
 Update `README.md` with the current output from `make help`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,11 @@ tools = "rhiza_tools.__main__:app"
 [tool.hatch.build.targets.wheel]
 packages = ["src/rhiza_tools"]
 
+[tool.ty.terminal]
+# Strict type-checking gate: any ty warning fails `make typecheck` / CI, not just
+# hard errors. Keeps the type surface honest as the code evolves.
+error-on-warning = true
+
 [tool.deptry.package_module_name_map]
 "bump-my-version" = "bumpversion"
 "loguru" = "loguru"

--- a/src/rhiza_tools/commands/_shared.py
+++ b/src/rhiza_tools/commands/_shared.py
@@ -13,12 +13,11 @@ Utilities:
 """
 
 import subprocess  # nosec B404 - subprocess needed for git operations
+import tomllib
 from pathlib import Path
-from typing import Any, cast
 
 import questionary as qs
 import semver
-import tomlkit
 import typer
 
 from rhiza_tools import console
@@ -92,10 +91,9 @@ def get_current_version() -> str:
         0.1.0
     """
     try:
-        with open("pyproject.toml") as f:
-            data = tomlkit.parse(f.read())
-            project = cast(dict[str, Any], data["project"])
-            return str(project["version"])
+        with open("pyproject.toml", "rb") as f:
+            data = tomllib.load(f)
+        return str(data["project"]["version"])
     except Exception as e:
         console.error(f"Failed to read version from pyproject.toml: {e}")
         raise typer.Exit(code=1) from None

--- a/src/rhiza_tools/commands/bump.py
+++ b/src/rhiza_tools/commands/bump.py
@@ -19,6 +19,7 @@ Example:
         bump_command(None)
 """
 
+import tomllib
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
@@ -27,7 +28,6 @@ from typing import Any, cast
 
 import questionary as qs
 import semver
-import tomlkit
 import typer
 from bumpversion.bump import do_bump
 from bumpversion.config import get_configuration
@@ -198,13 +198,11 @@ def get_current_version(language: Language) -> str:
     """
     if language == Language.PYTHON:
         try:
-            with open("pyproject.toml") as f:
-                data = tomlkit.parse(f.read())
-                project = cast(dict[str, Any], data["project"])
-                version = str(project["version"])
-                # Convert PEP 440 format back to semver format for compatibility
-                # e.g., 0.1.1a1 -> 0.1.1-alpha.1
-                return _denormalize_pep440_to_semver(version)
+            with open("pyproject.toml", "rb") as f:
+                data = tomllib.load(f)
+            # Convert PEP 440 format back to semver format for compatibility
+            # e.g., 0.1.1a1 -> 0.1.1-alpha.1
+            return _denormalize_pep440_to_semver(str(data["project"]["version"]))
         except Exception as e:
             console.error(f"Failed to read version from pyproject.toml: {e}")
             raise typer.Exit(code=1) from None

--- a/tests/test_doc_consistency.py
+++ b/tests/test_doc_consistency.py
@@ -1,0 +1,50 @@
+"""Consistency gate between the CLI commands and the README documentation.
+
+Every command registered on the Typer app must be documented in README.md, and
+every command documented there must exist. This keeps the docs from silently
+drifting as commands are added, removed or renamed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from rhiza_tools.cli import app
+
+README = Path(__file__).resolve().parent.parent / "README.md"
+
+
+def _normalize(name: str) -> str:
+    """Normalize a command name for comparison (Typer maps underscores to hyphens)."""
+    return name.replace("_", "-")
+
+
+def _registered_command_names() -> set[str]:
+    """Return the normalized names of every command registered on the Typer app."""
+    names: set[str] = set()
+    for command in app.registered_commands:
+        raw = command.name or (command.callback.__name__ if command.callback else None)
+        assert raw, "every registered command must resolve to a name"
+        names.add(_normalize(raw))
+    return names
+
+
+def _documented_command_names() -> set[str]:
+    """Return command names documented as ``### `name` `` headers in the Commands section."""
+    text = README.read_text(encoding="utf-8")
+    # Restrict to the "## Commands" section so unrelated headers are not matched.
+    commands_section = text.split("## Commands", 1)[-1].split("\n## ", 1)[0]
+    return {_normalize(m) for m in re.findall(r"^### `([^`]+)`", commands_section, flags=re.MULTILINE)}
+
+
+def test_every_command_is_documented():
+    """Each registered CLI command must appear as a documented section in the README."""
+    missing = _registered_command_names() - _documented_command_names()
+    assert not missing, f"commands missing from the README Commands section: {sorted(missing)}"
+
+
+def test_every_documented_command_exists():
+    """Each command documented in the README must be a real registered command."""
+    stale = _documented_command_names() - _registered_command_names()
+    assert not stale, f"README documents non-existent commands: {sorted(stale)}"

--- a/tests/test_versioning_guard_1126.py
+++ b/tests/test_versioning_guard_1126.py
@@ -114,6 +114,16 @@ def test_baseline_falls_back_to_local_when_remote_unknown(monkeypatch):
     assert _resolve_bump_baseline("0.3.2") == "0.3.2"
 
 
+def test_baseline_uses_remote_when_local_version_is_unparseable(monkeypatch):
+    """An unparseable local version falls back to the remote tag as the baseline.
+
+    A corrupt or non-semver ``version`` in pyproject.toml must not crash the bump
+    or let a relative bump compute from nothing — the remote tag is authoritative.
+    """
+    monkeypatch.setattr(bump_mod, "get_latest_remote_version", lambda *a, **k: semver.Version.parse("0.4.0"))
+    assert _resolve_bump_baseline("not-a-semver") == "0.4.0"
+
+
 def test_bump_patch_from_stale_branch_jumps_past_remote(bump_project, monkeypatch):
     """End-to-end: `bump patch` on a stale 0.3.2 branch yields 0.4.1, not 0.3.3."""
     pyproject = bump_project / "pyproject.toml"
@@ -160,6 +170,18 @@ def test_monotonic_skipped_when_no_remote_tags(monkeypatch):
     """First release (no remote tags) is always allowed."""
     _patch_remote_latest(monkeypatch, None)
     release_mod._check_release_version_monotonic("0.1.0", allow_older=False)  # no raise
+
+
+def test_monotonic_rejects_unparseable_candidate(monkeypatch):
+    """An unparseable candidate version is a hard error, not a silent pass.
+
+    Once a remote release exists the guard must be able to compare against it; a
+    version string it cannot parse is treated as a fatal misconfiguration.
+    """
+    _patch_remote_latest(monkeypatch, "0.4.0")
+    with pytest.raises(typer.Exit) as excinfo:
+        release_mod._check_release_version_monotonic("not-a-semver", allow_older=False)
+    assert excinfo.value.exit_code == 1
 
 
 # ── release_command integration ───────────────────────────────────────────────


### PR DESCRIPTION
Part of the **"10 across the board"** plan (epic #212).

> ⚠️ Branched off #205 (changelog-fold), so until #205 merges this PR's diff also includes that commit. It will shrink automatically once #205 lands.

### Closes #210 — Docs gate
- Documented the previously-undocumented `rollback` command.
- `tests/test_doc_consistency.py`: every Typer-registered command must be documented in the README, and every documented command must exist (normalizing Typer's `_`→`-`).

### Closes #209 — Type safety
- Read `[project].version` via stdlib `tomllib` instead of `cast(dict[str, Any], …)` over a tomlkit doc, in both `bump.get_current_version` and `_shared.get_current_version`. Removes the cast and `_shared`'s now-unused `Any`/`cast`/`tomlkit` imports (tomlkit stays — `config.py` uses it).
- `[tool.ty] terminal.error-on-warning = true` — any ty warning now fails `make typecheck`/CI.

### Coverage → 100%
- Behavior tests for the two invalid-semver fallbacks (`_resolve_bump_baseline` → remote tag; `_check_release_version_monotonic` → hard error). Real assertions, not coverage-chasing.

### Verification
`make test`: **434 passed, 100% coverage.** `make typecheck` (strict), `ruff`, `deptry`, `interrogate`, `bandit` all green.

### Not in this PR (larger refactors, separate PRs)
- #206 (mutation gate + relocate coverage-chasing tests), #207 (split `bump.py` + complexity gate), #208 (bump-my-version adapter + contract test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)