### PR TITLE
refactor(bump): split into versioning/engine + complexity/size gates (#207, #208)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -77,6 +77,7 @@ extend-select = [
     #"T10",   # flake8-debugger - Check for debugger imports and calls
     "TRY",   # flake8-try-except-raise - Try/except/raise checks
     "ICN",   # flake8-import-conventions - Import convention enforcement
+    "C901",  # mccabe - Flag overly complex functions (cyclomatic complexity)
     #"PIE",   # flake8-pie - Miscellaneous rules
     #"PL",    # Pylint rules
 ]
@@ -86,6 +87,10 @@ ignore = [
     "D203",  # one-blank-line-before-class (conflicts with D211)
     "D213",  # multi-line-summary-second-line (conflicts with D212)
 ]
+
+[lint.mccabe]
+# Maximum cyclomatic complexity allowed before C901 fires.
+max-complexity = 10
 
 [lint.pydocstyle]
 convention = "google"
@@ -113,6 +118,7 @@ line-ending = "auto"
     "PLR2004",  # Allow magic values in project tests
     "RUF002",   # Allow ambiguous unicode in project tests
     "RUF012",   # Allow mutable class attributes in project tests
+    "C901",     # Complexity gate targets production code; tests use elaborate mock setups
 ]
 # Marimo notebooks - allow flexible coding patterns for interactive exploration
 "**/notebooks/*.py" = [

--- a/src/rhiza_tools/commands/bump.py
+++ b/src/rhiza_tools/commands/bump.py
@@ -20,7 +20,6 @@ Example:
 """
 
 import tomllib
-from collections.abc import Callable
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -29,9 +28,6 @@ from typing import Any, cast
 import questionary as qs
 import semver
 import typer
-from bumpversion.bump import do_bump
-from bumpversion.config import get_configuration
-from bumpversion.ui import setup_logging
 from loguru import logger
 
 from rhiza_tools import console
@@ -42,52 +38,49 @@ from rhiza_tools.commands._shared import (
     get_latest_remote_version,
     run_git_command,
 )
-from rhiza_tools.config import CONFIG_FILENAME
 
+# Re-export the bump-my-version adapter helpers for the same reason. Names called
+# directly inside this module (bump_command) need no alias; pure re-exports use one.
+from rhiza_tools.commands.bump_engine import (
+    _build_changelog_hooks,
+    _build_configuration,
+    _execute_bump,
+    _get_files_to_modify,
+    _preflight_bump,
+    _preview_file_modifications,
+)
+from rhiza_tools.commands.bump_engine import (
+    _show_file_changes as _show_file_changes,
+)
 
-def _denormalize_pep440_to_semver(version_str: str) -> str:
-    """Convert PEP 440 prerelease format to semver format.
-
-    Converts PEP 440 format (e.g., 0.1.1a1 or 0.1.1alpha1) back to semver format
-    (e.g., 0.1.1-alpha.1) for compatibility with the semver library and bump-my-version.
-
-    Args:
-        version_str: Version string, possibly in PEP 440 format.
-
-    Returns:
-        Version string in semver format.
-
-    Example:
-        >>> _denormalize_pep440_to_semver("0.1.1a1")
-        '0.1.1-alpha.1'
-        >>> _denormalize_pep440_to_semver("0.1.1alpha1")
-        '0.1.1-alpha.1'
-        >>> _denormalize_pep440_to_semver("0.1.1")
-        '0.1.1'
-    """
-    import re
-
-    # Pattern to match PEP 440 prerelease: 0.1.1a1, 0.1.1alpha1, 0.1.1b2, 0.1.1rc3
-    # Captures: major.minor.patch, release letter(s), and pre_n
-    pattern = r"^(\d+\.\d+\.\d+)(a|alpha|b|beta|rc|dev)(\d+)$"
-    match = re.match(pattern, version_str)
-
-    if match:
-        base, release_short, pre_n = match.groups()
-        # Map PEP 440 forms to full names for semver
-        release_map = {
-            "a": "alpha",
-            "alpha": "alpha",
-            "b": "beta",
-            "beta": "beta",
-            "rc": "rc",
-            "dev": "dev",
-        }
-        release_full = release_map.get(release_short, release_short)
-        return f"{base}-{release_full}.{pre_n}"
-
-    # If not a PEP 440 prerelease, return as-is
-    return version_str
+# Re-export pure version-math helpers so external callers and tests that reference
+# ``rhiza_tools.commands.bump.<name>`` (including monkeypatch string paths) keep
+# working after these moved to bump_versioning. The redundant ``as`` aliases mark
+# them as intentional re-exports for ruff (F401).
+from rhiza_tools.commands.bump_versioning import (
+    _CHOICE_PREFIX_TO_BUMP_TYPE as _CHOICE_PREFIX_TO_BUMP_TYPE,
+)
+from rhiza_tools.commands.bump_versioning import (
+    _VALID_BUMP_TYPES as _VALID_BUMP_TYPES,
+)
+from rhiza_tools.commands.bump_versioning import (
+    _denormalize_pep440_to_semver as _denormalize_pep440_to_semver,
+)
+from rhiza_tools.commands.bump_versioning import (
+    _determine_bump_type_from_choice as _determine_bump_type_from_choice,
+)
+from rhiza_tools.commands.bump_versioning import (
+    _parse_version_argument,
+)
+from rhiza_tools.commands.bump_versioning import (
+    _validate_explicit_version as _validate_explicit_version,
+)
+from rhiza_tools.commands.bump_versioning import (
+    get_bumped_version_from_type as get_bumped_version_from_type,
+)
+from rhiza_tools.commands.bump_versioning import (
+    get_next_prerelease as get_next_prerelease,
+)
 
 
 class Language(StrEnum):
@@ -135,23 +128,6 @@ class Language(StrEnum):
             return Path("pyproject.toml")
         # Language.GO
         return Path("VERSION")
-
-
-# Valid bump type keywords
-_VALID_BUMP_TYPES = ["patch", "minor", "major", "prerelease", "build", "alpha", "beta", "rc", "dev"]
-
-# Mapping of choice prefix to bump type for interactive selection
-_CHOICE_PREFIX_TO_BUMP_TYPE = {
-    "Patch": "patch",
-    "Minor": "minor",
-    "Major": "major",
-    "Alpha": "alpha",
-    "Beta": "beta",
-    "RC": "rc",
-    "Dev": "dev",
-    "Prerelease": "prerelease",
-    "Build": "build",
-}
 
 
 @dataclass
@@ -227,52 +203,6 @@ def get_current_version(language: Language) -> str:
     else:
         console.error(f"Unsupported language: {language}")
         raise typer.Exit(code=1)
-
-
-def get_next_prerelease(current_version: semver.Version, token: str) -> semver.Version:
-    """Calculate next prerelease version for a given token.
-
-    Args:
-        current_version: The current semantic version.
-        token: The prerelease token (e.g., "alpha", "beta", "rc", "dev").
-
-    Returns:
-        The next prerelease version with the specified token.
-
-    Example:
-        >>> import semver
-        >>> current = semver.Version.parse("1.0.0")
-        >>> next_alpha = get_next_prerelease(current, "alpha")
-        >>> print(next_alpha)
-        1.0.1-alpha.1
-    """
-    if current_version.prerelease:
-        if current_version.prerelease.startswith(token):
-            return current_version.bump_prerelease()
-        else:
-            return current_version.replace(prerelease=f"{token}.1")
-    else:
-        return current_version.bump_patch().bump_prerelease(token=token)
-
-
-def _determine_bump_type_from_choice(choice: str) -> str:
-    """Extract bump type from interactive choice string.
-
-    Args:
-        choice: The choice string selected by the user (e.g., "Patch (1.0.0 -> 1.0.1)").
-
-    Returns:
-        The bump type extracted from the choice prefix (e.g., "patch").
-
-    Example:
-        >>> bump_type = _determine_bump_type_from_choice("Patch (1.0.0 -> 1.0.1)")
-        >>> print(bump_type)
-        patch
-    """
-    for prefix, bump_type in _CHOICE_PREFIX_TO_BUMP_TYPE.items():
-        if choice.startswith(prefix):
-            return bump_type
-    return ""
 
 
 def get_interactive_bump_type(current_version_str: str) -> str:
@@ -352,102 +282,6 @@ def get_interactive_bump_type(current_version_str: str) -> str:
     return new_version
 
 
-def get_bumped_version_from_type(current_version: semver.Version, version_type: str) -> str:
-    """Get bumped version string from version type keyword.
-
-    Args:
-        current_version: The current semantic version.
-        version_type: The bump type keyword.
-
-    Returns:
-        The bumped version string.
-    """
-    bump_mapping: dict[str, Callable[[], semver.Version]] = {
-        "patch": current_version.bump_patch,
-        "minor": current_version.bump_minor,
-        "major": current_version.bump_major,
-        "prerelease": current_version.bump_prerelease,
-        "build": current_version.bump_build,
-    }
-
-    if version_type in bump_mapping:
-        return str(bump_mapping[version_type]())
-    elif version_type in ["alpha", "beta", "rc", "dev"]:
-        return str(get_next_prerelease(current_version, version_type))
-
-    return ""
-
-
-def _validate_explicit_version(version: str) -> str:
-    """Validate and clean explicit version string.
-
-    Args:
-        version: Version string to validate.
-
-    Returns:
-        Cleaned version string.
-
-    Raises:
-        typer.Exit: If version format is invalid.
-    """
-    # Strip 'v' prefix
-    cleaned_version = version[1:] if version.startswith("v") else version
-
-    # Validate explicit version
-    try:
-        semver.Version.parse(cleaned_version)
-    except ValueError:
-        console.error(f"Invalid version format: {version}")
-        console.error("Please use a valid semantic version.")
-        raise typer.Exit(code=1) from None
-
-    return cleaned_version
-
-
-def _parse_version_argument(version: str | None, current_version_str: str) -> str:
-    """Parse version argument and return explicit version string.
-
-    Converts bump type keywords (patch, minor, major, etc.) to explicit version
-    strings, or validates and returns explicit version strings.
-
-    Args:
-        version: The version argument provided by the user. Can be a bump type
-            keyword or an explicit version string.
-        current_version_str: The current version string.
-
-    Returns:
-        The explicit version string to bump to, or empty string if version is None.
-
-    Raises:
-        typer.Exit: If the version format is invalid.
-
-    Example:
-        >>> version = _parse_version_argument("patch", "1.0.0")
-        >>> print(version)
-        1.0.1
-
-        >>> version = _parse_version_argument("2.0.0", "1.0.0")
-        >>> print(version)
-        2.0.0
-    """
-    if not version:
-        return ""
-
-    try:
-        current_version = semver.Version.parse(current_version_str)
-    except ValueError:
-        console.error(f"Invalid semantic version: {current_version_str}")
-        raise typer.Exit(code=1) from None
-
-    # Try to get bumped version from type keyword
-    bumped_version = get_bumped_version_from_type(current_version, version)
-    if bumped_version:
-        return bumped_version
-
-    # Otherwise, it's an explicit version - validate and return
-    return _validate_explicit_version(version)
-
-
 def _validate_project_exists(language: Language) -> None:
     """Validate that required project files exist for the specified language.
 
@@ -474,222 +308,6 @@ def _validate_project_exists(language: Language) -> None:
     else:
         console.error(f"Unsupported language: {language}")
         raise typer.Exit(code=1)
-
-
-def _build_configuration(
-    current_version_str: str,
-    allow_dirty: bool,
-    commit: bool,
-    config_path: Path | None = None,
-) -> tuple[Any, Path]:
-    """Build bumpversion configuration with appropriate overrides.
-
-    Args:
-        current_version_str: The current version string.
-        allow_dirty: If True, allow bumping even with uncommitted changes.
-        commit: If True, automatically commit the version change to git.
-        config_path: Path to the .cfg.toml config file. Defaults to CONFIG_FILENAME.
-
-    Returns:
-        A tuple of (config object, config_path).
-
-    Raises:
-        typer.Exit: If configuration loading fails.
-    """
-    if config_path is None:
-        config_path = Path(CONFIG_FILENAME)
-    overrides: dict[str, Any] = {"current_version": current_version_str}
-    if allow_dirty:
-        overrides["allow_dirty"] = True
-    if commit:
-        overrides["commit"] = True
-
-    try:
-        config = get_configuration(config_file=config_path, **overrides)
-    except Exception as e:
-        console.error(f"Failed to load bumpversion configuration: {e}")
-        console.error(f"Check your bumpversion config at: {config_path}")
-        console.error("Ensure the [tool.bumpversion] section is valid TOML with correct version patterns.")
-        raise typer.Exit(code=1) from None
-    else:
-        return config, config_path
-
-
-def _build_changelog_hooks(new_version: str) -> list[str]:
-    """Build git-cliff pre-commit hooks that fold CHANGELOG.md into the bump commit.
-
-    bump-my-version commits whatever is staged when it runs its ``pre_commit_hooks`` —
-    the same mechanism the project config already uses to include ``uv.lock``.
-    Regenerating the changelog there means the version bump, the lockfile and the
-    changelog land in a single commit and tag, with no separate push to the default
-    branch. That separate push is undesirable: it is blocked by branch-protection
-    rulesets and counts as an unreviewed change against the OpenSSF Scorecard
-    Code-Review check.
-
-    The hooks are only emitted when the project is configured for git-cliff (a
-    ``cliff.toml`` is present), so projects without changelog tooling are unaffected.
-    The new version is passed with ``--tag`` because the release tag does not exist
-    yet when the hooks run; otherwise git-cliff would file the new entries under
-    "unreleased".
-
-    Args:
-        new_version: The version being bumped to (without a leading ``v``).
-
-    Returns:
-        The git-cliff hook commands, or an empty list when git-cliff is not configured.
-
-    Example:
-        >>> _build_changelog_hooks("1.2.3")  # doctest: +SKIP
-        ['uvx git-cliff --tag v1.2.3 --output CHANGELOG.md', 'git add CHANGELOG.md']
-    """
-    if not (Path("cliff.toml").exists() or Path(".cliff.toml").exists()):
-        return []
-    return [
-        f"uvx git-cliff --tag v{new_version} --output CHANGELOG.md",
-        "git add CHANGELOG.md",
-    ]
-
-
-def _get_files_to_modify(config: Any) -> list[Path]:
-    """Get list of files that will be modified by bump-my-version.
-
-    Args:
-        config: The bumpversion configuration object.
-
-    Returns:
-        List of file paths that will be modified.
-    """
-    files = []
-    if hasattr(config, "files_to_modify"):
-        for file_config in config.files_to_modify:
-            if hasattr(file_config, "filename"):
-                files.append(Path(file_config.filename))
-    return files
-
-
-def _show_file_changes(file_path: Path, current_version: str, new_version: str) -> None:
-    """Show the changes that will be made to a file.
-
-    Args:
-        file_path: Path to the file to preview.
-        current_version: The current version string.
-        new_version: The new version string.
-    """
-    if not file_path.exists():
-        console.warning(f"File not found: {file_path}")
-        return
-
-    try:
-        content = file_path.read_text()
-        lines_with_version = []
-
-        for i, line in enumerate(content.split("\n"), 1):
-            if current_version in line:
-                lines_with_version.append((i, line))
-
-        if lines_with_version:
-            console.info(f"  Changes in {typer.style(str(file_path), fg=typer.colors.CYAN, bold=True)}:")
-            for line_num, old_line in lines_with_version:
-                new_line = old_line.replace(current_version, new_version)
-                console.info(f"    Line {line_num}:")
-                console.info(f"      {typer.style('-', fg=typer.colors.RED)} {old_line.strip()}")
-                console.info(f"      {typer.style('+', fg=typer.colors.GREEN)} {new_line.strip()}")
-    except Exception as e:
-        logger.debug(f"Could not preview changes for {file_path}: {e}")
-
-
-def _preview_file_modifications(config: Any, current_version: str, new_version: str) -> None:
-    """Preview what changes will be made to files.
-
-    Args:
-        config: The bumpversion configuration object.
-        current_version: The current version string.
-        new_version: The new version string.
-    """
-    files = _get_files_to_modify(config)
-
-    if files:
-        console.info(f"\n{typer.style('Files to be modified:', fg=typer.colors.YELLOW, bold=True)}")
-        for file_path in files:
-            _show_file_changes(file_path, current_version, new_version)
-        console.info("")  # Empty line for spacing
-    else:
-        # Fallback: check common files
-        common_files = [Path("pyproject.toml"), Path("VERSION"), Path("setup.py"), Path("setup.cfg")]
-        console.info(f"\n{typer.style('Files to be modified:', fg=typer.colors.YELLOW, bold=True)}")
-        for file_path in common_files:
-            if file_path.exists():
-                _show_file_changes(file_path, current_version, new_version)
-        console.info("")  # Empty line for spacing
-
-
-def _preflight_bump(new_version_str: str, config: Any, config_path: Path) -> None:
-    """Run a dry-run bump to validate the operation would succeed.
-
-    This preflight check ensures the bump operation will succeed before making
-    any actual changes. It catches configuration errors, file access issues,
-    and version format problems early, preventing partial failures that would
-    leave the repository in a state requiring manual recovery.
-
-    Args:
-        new_version_str: The new version string to validate.
-        config: The bumpversion configuration object.
-        config_path: Path to the bumpversion configuration file.
-
-    Raises:
-        typer.Exit: If the preflight validation fails.
-    """
-    console.info("Running preflight validation (dry-run)...")
-    setup_logging(verbose=1 if console.is_verbose() else 0)
-
-    try:
-        do_bump(
-            version_part=None,
-            new_version=new_version_str,
-            config=config,
-            config_file=config_path,
-            dry_run=True,
-        )
-    except Exception as e:
-        console.error(f"Preflight validation failed: {e}")
-        console.error("No changes were made.")
-        raise typer.Exit(code=1) from None
-
-    console.success("Preflight validation passed")
-
-
-def _execute_bump(new_version_str: str, config: Any, config_path: Path, dry_run: bool) -> None:
-    """Execute the bump operation using bump-my-version.
-
-    Args:
-        new_version_str: The new version string to bump to.
-        config: The bumpversion configuration object.
-        config_path: Path to the bumpversion configuration file.
-        dry_run: If True, show what would change without actually changing anything.
-
-    Raises:
-        typer.Exit: If the bump operation fails.
-    """
-    console.info("Running bump-my-version...")
-    setup_logging(verbose=1 if console.is_verbose() else 0)
-
-    try:
-        do_bump(
-            version_part=None,
-            new_version=new_version_str,
-            config=config,
-            config_file=config_path,
-            dry_run=dry_run,
-        )
-    except Exception as e:
-        console.error(f"bump-my-version failed: {e}")
-        if not dry_run:
-            console.error("Files may have been partially modified. To recover:")
-            console.error("  1. Check modified files: git diff")
-            console.error("  2. Restore all changes:  git checkout -- .")
-            console.error("  3. Remove untracked:     git clean -fd")
-            console.error("Or to keep changes, fix the issue and retry.")
-        raise typer.Exit(code=1) from None
 
 
 def _log_bump_success(current_version_str: str, config: Any, language: Language) -> None:
@@ -906,6 +524,68 @@ def _resolve_bump_baseline(current_version_str: str) -> str:
     return current_version_str
 
 
+def _resolve_language(options: BumpOptions) -> Language:
+    """Resolve the project language from options, auto-detecting when unset.
+
+    Args:
+        options: Configuration options for the bump command.
+
+    Returns:
+        The resolved programming language.
+
+    Raises:
+        typer.Exit: If no language is given and none can be detected.
+    """
+    if options.language is None:
+        detected_language = Language.detect()
+        if detected_language is None:
+            console.error("Unable to detect project language.")
+            console.error("Please specify language explicitly with --language option.")
+            console.error("Supported languages: python, go")
+            raise typer.Exit(code=1)
+        language = detected_language
+        console.info(f"Detected language: {typer.style(language.value, fg=typer.colors.CYAN, bold=True)}")
+    else:
+        language = options.language
+        console.info(f"Using language: {typer.style(language.value, fg=typer.colors.CYAN, bold=True)}")
+    return language
+
+
+def _finalize_bump(
+    options: BumpOptions,
+    current_version_str: str,
+    config: Any,
+    language: Language,
+    commit: bool,
+    push: bool,
+) -> None:
+    """Report the outcome of a bump and push to remote when requested.
+
+    In dry-run mode this only logs what would have happened; otherwise it logs
+    the successful bump and, if ``push`` is set, pushes the changes to the remote.
+
+    Args:
+        options: Configuration options for the bump command.
+        current_version_str: The original version string before the bump.
+        config: The bumpversion configuration object.
+        language: The programming language (python or go).
+        commit: Whether the bump committed the change.
+        push: Whether to push the change to the remote.
+    """
+    if options.dry_run:
+        console.info("[DRY-RUN] Bump completed (no changes made)")
+        if commit:
+            console.info("[DRY-RUN] Would commit the changes")
+        if push:
+            console.info("[DRY-RUN] Would push changes to remote")
+    else:
+        _log_bump_success(current_version_str, config, language)
+
+        # Handle push
+        if push:
+            _handle_push_to_remote(options.version)
+
+
 def bump_command(options: BumpOptions) -> None:
     """Bump version using bump-my-version.
 
@@ -943,18 +623,7 @@ def bump_command(options: BumpOptions) -> None:
             bump_command(BumpOptions(version="minor", push=True))
     """
     # Detect or use provided language
-    if options.language is None:
-        detected_language = Language.detect()
-        if detected_language is None:
-            console.error("Unable to detect project language.")
-            console.error("Please specify language explicitly with --language option.")
-            console.error("Supported languages: python, go")
-            raise typer.Exit(code=1)
-        language = detected_language
-        console.info(f"Detected language: {typer.style(language.value, fg=typer.colors.CYAN, bold=True)}")
-    else:
-        language = options.language
-        console.info(f"Using language: {typer.style(language.value, fg=typer.colors.CYAN, bold=True)}")
+    language = _resolve_language(options)
 
     _validate_project_exists(language)
 
@@ -1023,18 +692,7 @@ def bump_command(options: BumpOptions) -> None:
 
     _execute_bump(new_version_str, config, config_path, options.dry_run)
 
-    if options.dry_run:
-        console.info("[DRY-RUN] Bump completed (no changes made)")
-        if commit:
-            console.info("[DRY-RUN] Would commit the changes")
-        if push:
-            console.info("[DRY-RUN] Would push changes to remote")
-    else:
-        _log_bump_success(current_version_str, config, language)
-
-        # Handle push
-        if push:
-            _handle_push_to_remote(options.version)
+    _finalize_bump(options, current_version_str, config, language, commit, push)
 
     # Restore original branch if we switched
     _restore_original_branch(original_branch, options.dry_run)

--- a/src/rhiza_tools/commands/bump_engine.py
+++ b/src/rhiza_tools/commands/bump_engine.py
@@ -1,0 +1,242 @@
+"""Adapter isolating all bump-my-version integration for the bump command.
+
+This module is the single place in rhiza-tools that touches bump-my-version
+internals (``bumpversion.bump.do_bump``, ``bumpversion.config.get_configuration``,
+``bumpversion.ui.setup_logging`` and the shape of the configuration object). All
+other modules go through the helpers defined here, so an upstream change in
+bump-my-version only has to be reconciled in one location. The companion
+contract test in ``tests/test_bumpversion_contract.py`` pins the upstream
+interface this adapter relies on.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import typer
+from bumpversion.bump import do_bump
+from bumpversion.config import get_configuration
+from bumpversion.ui import setup_logging
+from loguru import logger
+
+from rhiza_tools import console
+from rhiza_tools.config import CONFIG_FILENAME
+
+# bump-my-version's configuration object (``bumpversion.config.models.Config``).
+# Kept as ``Any`` so static typing stays permissive while documenting intent.
+BumpConfig = Any  # bump-my-version's bumpversion.config.models.Config
+
+
+def _build_configuration(
+    current_version_str: str,
+    allow_dirty: bool,
+    commit: bool,
+    config_path: Path | None = None,
+) -> tuple[BumpConfig, Path]:
+    """Build bumpversion configuration with appropriate overrides.
+
+    Args:
+        current_version_str: The current version string.
+        allow_dirty: If True, allow bumping even with uncommitted changes.
+        commit: If True, automatically commit the version change to git.
+        config_path: Path to the .cfg.toml config file. Defaults to CONFIG_FILENAME.
+
+    Returns:
+        A tuple of (config object, config_path).
+
+    Raises:
+        typer.Exit: If configuration loading fails.
+    """
+    if config_path is None:
+        config_path = Path(CONFIG_FILENAME)
+    overrides: dict[str, Any] = {"current_version": current_version_str}
+    if allow_dirty:
+        overrides["allow_dirty"] = True
+    if commit:
+        overrides["commit"] = True
+
+    try:
+        config = get_configuration(config_file=config_path, **overrides)
+    except Exception as e:
+        console.error(f"Failed to load bumpversion configuration: {e}")
+        console.error(f"Check your bumpversion config at: {config_path}")
+        console.error("Ensure the [tool.bumpversion] section is valid TOML with correct version patterns.")
+        raise typer.Exit(code=1) from None
+    else:
+        return config, config_path
+
+
+def _build_changelog_hooks(new_version: str) -> list[str]:
+    """Build git-cliff pre-commit hooks that fold CHANGELOG.md into the bump commit.
+
+    bump-my-version commits whatever is staged when it runs its ``pre_commit_hooks`` —
+    the same mechanism the project config already uses to include ``uv.lock``.
+    Regenerating the changelog there means the version bump, the lockfile and the
+    changelog land in a single commit and tag, with no separate push to the default
+    branch. That separate push is undesirable: it is blocked by branch-protection
+    rulesets and counts as an unreviewed change against the OpenSSF Scorecard
+    Code-Review check.
+
+    The hooks are only emitted when the project is configured for git-cliff (a
+    ``cliff.toml`` is present), so projects without changelog tooling are unaffected.
+    The new version is passed with ``--tag`` because the release tag does not exist
+    yet when the hooks run; otherwise git-cliff would file the new entries under
+    "unreleased".
+
+    Args:
+        new_version: The version being bumped to (without a leading ``v``).
+
+    Returns:
+        The git-cliff hook commands, or an empty list when git-cliff is not configured.
+
+    Example:
+        >>> _build_changelog_hooks("1.2.3")  # doctest: +SKIP
+        ['uvx git-cliff --tag v1.2.3 --output CHANGELOG.md', 'git add CHANGELOG.md']
+    """
+    if not (Path("cliff.toml").exists() or Path(".cliff.toml").exists()):
+        return []
+    return [
+        f"uvx git-cliff --tag v{new_version} --output CHANGELOG.md",
+        "git add CHANGELOG.md",
+    ]
+
+
+def _get_files_to_modify(config: BumpConfig) -> list[Path]:
+    """Get list of files that will be modified by bump-my-version.
+
+    Args:
+        config: The bumpversion configuration object.
+
+    Returns:
+        List of file paths that will be modified.
+    """
+    files = []
+    if hasattr(config, "files_to_modify"):
+        for file_config in config.files_to_modify:
+            if hasattr(file_config, "filename"):
+                files.append(Path(file_config.filename))
+    return files
+
+
+def _show_file_changes(file_path: Path, current_version: str, new_version: str) -> None:
+    """Show the changes that will be made to a file.
+
+    Args:
+        file_path: Path to the file to preview.
+        current_version: The current version string.
+        new_version: The new version string.
+    """
+    if not file_path.exists():
+        console.warning(f"File not found: {file_path}")
+        return
+
+    try:
+        content = file_path.read_text()
+        lines_with_version = []
+
+        for i, line in enumerate(content.split("\n"), 1):
+            if current_version in line:
+                lines_with_version.append((i, line))
+
+        if lines_with_version:
+            console.info(f"  Changes in {typer.style(str(file_path), fg=typer.colors.CYAN, bold=True)}:")
+            for line_num, old_line in lines_with_version:
+                new_line = old_line.replace(current_version, new_version)
+                console.info(f"    Line {line_num}:")
+                console.info(f"      {typer.style('-', fg=typer.colors.RED)} {old_line.strip()}")
+                console.info(f"      {typer.style('+', fg=typer.colors.GREEN)} {new_line.strip()}")
+    except Exception as e:
+        logger.debug(f"Could not preview changes for {file_path}: {e}")
+
+
+def _preview_file_modifications(config: BumpConfig, current_version: str, new_version: str) -> None:
+    """Preview what changes will be made to files.
+
+    Args:
+        config: The bumpversion configuration object.
+        current_version: The current version string.
+        new_version: The new version string.
+    """
+    files = _get_files_to_modify(config)
+
+    if files:
+        console.info(f"\n{typer.style('Files to be modified:', fg=typer.colors.YELLOW, bold=True)}")
+        for file_path in files:
+            _show_file_changes(file_path, current_version, new_version)
+        console.info("")  # Empty line for spacing
+    else:
+        # Fallback: check common files
+        common_files = [Path("pyproject.toml"), Path("VERSION"), Path("setup.py"), Path("setup.cfg")]
+        console.info(f"\n{typer.style('Files to be modified:', fg=typer.colors.YELLOW, bold=True)}")
+        for file_path in common_files:
+            if file_path.exists():
+                _show_file_changes(file_path, current_version, new_version)
+        console.info("")  # Empty line for spacing
+
+
+def _preflight_bump(new_version_str: str, config: BumpConfig, config_path: Path) -> None:
+    """Run a dry-run bump to validate the operation would succeed.
+
+    This preflight check ensures the bump operation will succeed before making
+    any actual changes. It catches configuration errors, file access issues,
+    and version format problems early, preventing partial failures that would
+    leave the repository in a state requiring manual recovery.
+
+    Args:
+        new_version_str: The new version string to validate.
+        config: The bumpversion configuration object.
+        config_path: Path to the bumpversion configuration file.
+
+    Raises:
+        typer.Exit: If the preflight validation fails.
+    """
+    console.info("Running preflight validation (dry-run)...")
+    setup_logging(verbose=1 if console.is_verbose() else 0)
+
+    try:
+        do_bump(
+            version_part=None,
+            new_version=new_version_str,
+            config=config,
+            config_file=config_path,
+            dry_run=True,
+        )
+    except Exception as e:
+        console.error(f"Preflight validation failed: {e}")
+        console.error("No changes were made.")
+        raise typer.Exit(code=1) from None
+
+    console.success("Preflight validation passed")
+
+
+def _execute_bump(new_version_str: str, config: BumpConfig, config_path: Path, dry_run: bool) -> None:
+    """Execute the bump operation using bump-my-version.
+
+    Args:
+        new_version_str: The new version string to bump to.
+        config: The bumpversion configuration object.
+        config_path: Path to the bumpversion configuration file.
+        dry_run: If True, show what would change without actually changing anything.
+
+    Raises:
+        typer.Exit: If the bump operation fails.
+    """
+    console.info("Running bump-my-version...")
+    setup_logging(verbose=1 if console.is_verbose() else 0)
+
+    try:
+        do_bump(
+            version_part=None,
+            new_version=new_version_str,
+            config=config,
+            config_file=config_path,
+            dry_run=dry_run,
+        )
+    except Exception as e:
+        console.error(f"bump-my-version failed: {e}")
+        if not dry_run:
+            console.error("Files may have been partially modified. To recover:")
+            console.error("  1. Check modified files: git diff")
+            console.error("  2. Restore all changes:  git checkout -- .")
+            console.error("  3. Remove untracked:     git clean -fd")
+            console.error("Or to keep changes, fix the issue and retry.")
+        raise typer.Exit(code=1) from None

--- a/src/rhiza_tools/commands/bump_versioning.py
+++ b/src/rhiza_tools/commands/bump_versioning.py
@@ -1,0 +1,219 @@
+"""Pure version-math helpers for the bump command.
+
+This module contains the version-arithmetic building blocks used by the bump
+command: PEP 440 / semver normalization, prerelease calculation, bump-type
+resolution, and version-argument parsing. It deliberately contains no
+interactive (``questionary``) code and no bump-my-version integration so the
+version logic can be reasoned about and tested in isolation.
+"""
+
+from collections.abc import Callable
+
+import semver
+import typer
+
+from rhiza_tools import console
+
+
+def _denormalize_pep440_to_semver(version_str: str) -> str:
+    """Convert PEP 440 prerelease format to semver format.
+
+    Converts PEP 440 format (e.g., 0.1.1a1 or 0.1.1alpha1) back to semver format
+    (e.g., 0.1.1-alpha.1) for compatibility with the semver library and bump-my-version.
+
+    Args:
+        version_str: Version string, possibly in PEP 440 format.
+
+    Returns:
+        Version string in semver format.
+
+    Example:
+        >>> _denormalize_pep440_to_semver("0.1.1a1")
+        '0.1.1-alpha.1'
+        >>> _denormalize_pep440_to_semver("0.1.1alpha1")
+        '0.1.1-alpha.1'
+        >>> _denormalize_pep440_to_semver("0.1.1")
+        '0.1.1'
+    """
+    import re
+
+    # Pattern to match PEP 440 prerelease: 0.1.1a1, 0.1.1alpha1, 0.1.1b2, 0.1.1rc3
+    # Captures: major.minor.patch, release letter(s), and pre_n
+    pattern = r"^(\d+\.\d+\.\d+)(a|alpha|b|beta|rc|dev)(\d+)$"
+    match = re.match(pattern, version_str)
+
+    if match:
+        base, release_short, pre_n = match.groups()
+        # Map PEP 440 forms to full names for semver
+        release_map = {
+            "a": "alpha",
+            "alpha": "alpha",
+            "b": "beta",
+            "beta": "beta",
+            "rc": "rc",
+            "dev": "dev",
+        }
+        release_full = release_map.get(release_short, release_short)
+        return f"{base}-{release_full}.{pre_n}"
+
+    # If not a PEP 440 prerelease, return as-is
+    return version_str
+
+
+# Valid bump type keywords
+_VALID_BUMP_TYPES = ["patch", "minor", "major", "prerelease", "build", "alpha", "beta", "rc", "dev"]
+
+# Mapping of choice prefix to bump type for interactive selection
+_CHOICE_PREFIX_TO_BUMP_TYPE = {
+    "Patch": "patch",
+    "Minor": "minor",
+    "Major": "major",
+    "Alpha": "alpha",
+    "Beta": "beta",
+    "RC": "rc",
+    "Dev": "dev",
+    "Prerelease": "prerelease",
+    "Build": "build",
+}
+
+
+def get_next_prerelease(current_version: semver.Version, token: str) -> semver.Version:
+    """Calculate next prerelease version for a given token.
+
+    Args:
+        current_version: The current semantic version.
+        token: The prerelease token (e.g., "alpha", "beta", "rc", "dev").
+
+    Returns:
+        The next prerelease version with the specified token.
+
+    Example:
+        >>> import semver
+        >>> current = semver.Version.parse("1.0.0")
+        >>> next_alpha = get_next_prerelease(current, "alpha")
+        >>> print(next_alpha)
+        1.0.1-alpha.1
+    """
+    if current_version.prerelease:
+        if current_version.prerelease.startswith(token):
+            return current_version.bump_prerelease()
+        else:
+            return current_version.replace(prerelease=f"{token}.1")
+    else:
+        return current_version.bump_patch().bump_prerelease(token=token)
+
+
+def _determine_bump_type_from_choice(choice: str) -> str:
+    """Extract bump type from interactive choice string.
+
+    Args:
+        choice: The choice string selected by the user (e.g., "Patch (1.0.0 -> 1.0.1)").
+
+    Returns:
+        The bump type extracted from the choice prefix (e.g., "patch").
+
+    Example:
+        >>> bump_type = _determine_bump_type_from_choice("Patch (1.0.0 -> 1.0.1)")
+        >>> print(bump_type)
+        patch
+    """
+    for prefix, bump_type in _CHOICE_PREFIX_TO_BUMP_TYPE.items():
+        if choice.startswith(prefix):
+            return bump_type
+    return ""
+
+
+def get_bumped_version_from_type(current_version: semver.Version, version_type: str) -> str:
+    """Get bumped version string from version type keyword.
+
+    Args:
+        current_version: The current semantic version.
+        version_type: The bump type keyword.
+
+    Returns:
+        The bumped version string.
+    """
+    bump_mapping: dict[str, Callable[[], semver.Version]] = {
+        "patch": current_version.bump_patch,
+        "minor": current_version.bump_minor,
+        "major": current_version.bump_major,
+        "prerelease": current_version.bump_prerelease,
+        "build": current_version.bump_build,
+    }
+
+    if version_type in bump_mapping:
+        return str(bump_mapping[version_type]())
+    elif version_type in ["alpha", "beta", "rc", "dev"]:
+        return str(get_next_prerelease(current_version, version_type))
+
+    return ""
+
+
+def _validate_explicit_version(version: str) -> str:
+    """Validate and clean explicit version string.
+
+    Args:
+        version: Version string to validate.
+
+    Returns:
+        Cleaned version string.
+
+    Raises:
+        typer.Exit: If version format is invalid.
+    """
+    # Strip 'v' prefix
+    cleaned_version = version[1:] if version.startswith("v") else version
+
+    # Validate explicit version
+    try:
+        semver.Version.parse(cleaned_version)
+    except ValueError:
+        console.error(f"Invalid version format: {version}")
+        console.error("Please use a valid semantic version.")
+        raise typer.Exit(code=1) from None
+
+    return cleaned_version
+
+
+def _parse_version_argument(version: str | None, current_version_str: str) -> str:
+    """Parse version argument and return explicit version string.
+
+    Converts bump type keywords (patch, minor, major, etc.) to explicit version
+    strings, or validates and returns explicit version strings.
+
+    Args:
+        version: The version argument provided by the user. Can be a bump type
+            keyword or an explicit version string.
+        current_version_str: The current version string.
+
+    Returns:
+        The explicit version string to bump to, or empty string if version is None.
+
+    Raises:
+        typer.Exit: If the version format is invalid.
+
+    Example:
+        >>> version = _parse_version_argument("patch", "1.0.0")
+        >>> print(version)
+        1.0.1
+
+        >>> version = _parse_version_argument("2.0.0", "1.0.0")
+        >>> print(version)
+        2.0.0
+    """
+    if not version:
+        return ""
+
+    try:
+        current_version = semver.Version.parse(current_version_str)
+    except ValueError:
+        console.error(f"Invalid semantic version: {current_version_str}")
+        raise typer.Exit(code=1) from None
+
+    # Try to get bumped version from type keyword
+    bumped_version = get_bumped_version_from_type(current_version, version)
+    if bumped_version:
+        return bumped_version
+
+    # Otherwise, it's an explicit version - validate and return
+    return _validate_explicit_version(version)

--- a/src/rhiza_tools/commands/rollback.py
+++ b/src/rhiza_tools/commands/rollback.py
@@ -511,6 +511,49 @@ def _should_revert_bump(options: RollbackOptions, exists_locally: bool, is_bump:
         return False
 
 
+def _delete_rollback_tags(
+    tag: str,
+    exists_locally: bool,
+    exists_remotely: bool,
+    dry_run: bool,
+) -> bool:
+    """Delete the remote then local tag for a rollback.
+
+    The remote tag is deleted first to stop any in-progress release. A failure
+    to delete the remote tag aborts the rollback in non-dry-run mode.
+
+    Args:
+        tag: The tag to delete.
+        exists_locally: Whether the tag exists locally.
+        exists_remotely: Whether the tag exists on remote.
+        dry_run: If True, only simulate changes.
+
+    Returns:
+        True if all attempted deletions succeeded.
+
+    Raises:
+        typer.Exit: If the remote tag deletion fails (non-dry-run).
+    """
+    success = True
+
+    # Delete remote tag first to stop any in-progress release
+    if exists_remotely and not _delete_remote_tag(tag, dry_run):
+        success = False
+        if not dry_run:
+            console.error("Failed to delete remote tag. Aborting remaining steps.")
+            console.error("You can retry or manually delete with:")
+            console.error(f"  git push origin :refs/tags/{tag}")
+            raise typer.Exit(code=1)
+
+    # Delete local tag
+    if exists_locally and not _delete_local_tag(tag, dry_run):
+        success = False
+        if not dry_run:
+            console.warning(f"Failed to delete local tag. Delete manually: git tag -d {tag}")
+
+    return success
+
+
 def _execute_rollback(
     tag: str,
     exists_locally: bool,
@@ -537,8 +580,6 @@ def _execute_rollback(
     Raises:
         typer.Exit: If the remote tag deletion fails (non-dry-run).
     """
-    success = True
-
     # Get commit hash BEFORE deleting tags (needed for revert)
     tag_commit = None
     if revert_bump and is_bump and exists_locally:
@@ -548,20 +589,7 @@ def _execute_rollback(
             console.error("Skipping bump revert but proceeding with tag deletion.")
             revert_bump = False
 
-    # Delete remote tag first to stop any in-progress release
-    if exists_remotely and not _delete_remote_tag(tag, dry_run):
-        success = False
-        if not dry_run:
-            console.error("Failed to delete remote tag. Aborting remaining steps.")
-            console.error("You can retry or manually delete with:")
-            console.error(f"  git push origin :refs/tags/{tag}")
-            raise typer.Exit(code=1)
-
-    # Delete local tag
-    if exists_locally and not _delete_local_tag(tag, dry_run):
-        success = False
-        if not dry_run:
-            console.warning(f"Failed to delete local tag. Delete manually: git tag -d {tag}")
+    success = _delete_rollback_tags(tag, exists_locally, exists_remotely, dry_run)
 
     # Revert bump commit and push (if requested)
     if revert_bump and is_bump and tag_commit:

--- a/tests/test_bump_command.py
+++ b/tests/test_bump_command.py
@@ -473,7 +473,7 @@ def test_bump_with_allow_dirty_flag(bump_project, monkeypatch):
 
         return real_get_config(*args, **kwargs)
 
-    monkeypatch.setattr("rhiza_tools.commands.bump.get_configuration", mock_get_config)
+    monkeypatch.setattr("rhiza_tools.commands.bump_engine.get_configuration", mock_get_config)
 
     # Test with allow_dirty=True
     bump_command(BumpOptions(version="patch", allow_dirty=True))
@@ -492,7 +492,7 @@ def test_bump_with_commit_flag(bump_project, monkeypatch):
 
         return real_get_config(*args, **kwargs)
 
-    monkeypatch.setattr("rhiza_tools.commands.bump.get_configuration", mock_get_config)
+    monkeypatch.setattr("rhiza_tools.commands.bump_engine.get_configuration", mock_get_config)
 
     # Test with commit=True
     bump_command(BumpOptions(version="patch", commit=True))
@@ -532,7 +532,7 @@ def test_bump_folds_changelog_hook_into_commit(bump_project, monkeypatch):
         if kwargs.get("dry_run") is False:
             captured["config"] = kwargs.get("config")
 
-    monkeypatch.setattr("rhiza_tools.commands.bump.do_bump", mock_do_bump)
+    monkeypatch.setattr("rhiza_tools.commands.bump_engine.do_bump", mock_do_bump)
 
     bump_command(BumpOptions(version="patch", commit=True))
 
@@ -549,7 +549,7 @@ def test_bump_without_cliff_config_adds_no_changelog_hook(bump_project, monkeypa
         if kwargs.get("dry_run") is False:
             captured["config"] = kwargs.get("config")
 
-    monkeypatch.setattr("rhiza_tools.commands.bump.do_bump", mock_do_bump)
+    monkeypatch.setattr("rhiza_tools.commands.bump_engine.do_bump", mock_do_bump)
 
     bump_command(BumpOptions(version="patch", commit=True))
 
@@ -563,7 +563,7 @@ def test_bump_configuration_load_failure(bump_project, monkeypatch):
     def mock_get_config(*args, **kwargs):
         raise Exception("Configuration load error")  # noqa: TRY002, TRY003
 
-    monkeypatch.setattr("rhiza_tools.commands.bump.get_configuration", mock_get_config)
+    monkeypatch.setattr("rhiza_tools.commands.bump_engine.get_configuration", mock_get_config)
 
     # Should fail with exit code 1
     with pytest.raises(typer.Exit) as excinfo:
@@ -577,7 +577,7 @@ def test_bump_operation_failure(bump_project, monkeypatch):
     def mock_do_bump(*args, **kwargs):
         raise Exception("Bump operation failed")  # noqa: TRY002, TRY003
 
-    monkeypatch.setattr("rhiza_tools.commands.bump.do_bump", mock_do_bump)
+    monkeypatch.setattr("rhiza_tools.commands.bump_engine.do_bump", mock_do_bump)
 
     # Should fail with exit code 1
     with pytest.raises(typer.Exit) as excinfo:
@@ -908,7 +908,7 @@ class TestPreflightValidation:
             # Should never reach the real call
             raise AssertionError("Real bump should not be called after preflight failure")  # noqa: TRY003
 
-        with patch("rhiza_tools.commands.bump.do_bump", side_effect=mock_do_bump):
+        with patch("rhiza_tools.commands.bump_engine.do_bump", side_effect=mock_do_bump):
             with pytest.raises(typer.Exit) as excinfo:
                 bump_command(BumpOptions(version="patch"))
             assert excinfo.value.exit_code == 1
@@ -930,7 +930,7 @@ class TestPreflightValidation:
 
             return real_do_bump(*args, **kwargs)
 
-        with patch("rhiza_tools.commands.bump.do_bump", side_effect=tracking_do_bump):
+        with patch("rhiza_tools.commands.bump_engine.do_bump", side_effect=tracking_do_bump):
             bump_command(BumpOptions(version="patch"))
 
         # Should have two calls: first dry-run (preflight), then real
@@ -951,7 +951,7 @@ class TestPreflightValidation:
 
             return real_do_bump(*args, **kwargs)
 
-        with patch("rhiza_tools.commands.bump.do_bump", side_effect=tracking_do_bump):
+        with patch("rhiza_tools.commands.bump_engine.do_bump", side_effect=tracking_do_bump):
             bump_command(BumpOptions(version="patch", dry_run=True))
 
         # Should have only one call (the actual dry-run), no preflight
@@ -1446,7 +1446,7 @@ class TestExecuteBump:
         mock_config_path = MagicMock()
 
         with (
-            patch("rhiza_tools.commands.bump.do_bump", side_effect=Exception("bump failed")),
+            patch("rhiza_tools.commands.bump_engine.do_bump", side_effect=Exception("bump failed")),
             pytest.raises(typer.Exit),
         ):
             _execute_bump("1.0.1", mock_config, mock_config_path, dry_run=False)
@@ -1459,7 +1459,7 @@ class TestExecuteBump:
         mock_config_path = MagicMock()
 
         with (
-            patch("rhiza_tools.commands.bump.do_bump", side_effect=Exception("bump failed")),
+            patch("rhiza_tools.commands.bump_engine.do_bump", side_effect=Exception("bump failed")),
             pytest.raises(typer.Exit),
         ):
             _execute_bump("1.0.1", mock_config, mock_config_path, dry_run=True)

--- a/tests/test_bumpversion_contract.py
+++ b/tests/test_bumpversion_contract.py
@@ -1,0 +1,36 @@
+"""Contract test pinning the bump-my-version interface rhiza-tools depends on.
+
+The bump engine (``rhiza_tools.commands.bump_engine``) appends git-cliff commands
+to a bump-my-version configuration's ``pre_commit_hooks`` list before running a
+real bump. That depends on upstream bump-my-version exposing a ``Config`` model
+with a list-typed ``pre_commit_hooks`` field. If a future upstream release renames
+or retypes that field, this test fails loudly here rather than at release time
+when a version bump would silently lose its changelog/lockfile staging.
+
+The check is intentionally cheap: it inspects the Pydantic model fields only and
+never runs a full bump.
+"""
+
+from __future__ import annotations
+
+from bumpversion.config.models import Config
+
+
+def test_config_exposes_pre_commit_hooks_field():
+    """``Config`` must still declare the ``pre_commit_hooks`` field."""
+    assert "pre_commit_hooks" in Config.model_fields
+
+
+def test_pre_commit_hooks_is_list_typed():
+    """``pre_commit_hooks`` must be a list type whose default factory yields a list."""
+    field = Config.model_fields["pre_commit_hooks"]
+
+    # The field annotation must be a list type (e.g. list[str] / typing.List[str]).
+    annotation_repr = repr(field.annotation)
+    assert "list" in annotation_repr.lower(), annotation_repr
+
+    # And its default must materialise as a list, since the engine does
+    # ``list(config.pre_commit_hooks) + [...]``.
+    assert field.default_factory is not None
+    default_value = field.default_factory()  # type: ignore[call-arg]
+    assert isinstance(default_value, list)

--- a/tests/test_module_size.py
+++ b/tests/test_module_size.py
@@ -1,0 +1,27 @@
+"""Module-size gate keeping command modules small enough to navigate.
+
+Issue #207 split the oversized ``bump.py`` into focused modules. This gate
+prevents regression: every command module must stay at or below an 800-line
+ceiling, so future growth is split out rather than accreted into one file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_MAX_LINES = 800
+_COMMANDS_DIR = Path(__file__).resolve().parent.parent / "src" / "rhiza_tools" / "commands"
+
+
+def test_command_modules_within_size_limit():
+    """Every ``src/rhiza_tools/commands/*.py`` must be at most 800 lines."""
+    offenders: dict[str, int] = {}
+    for module_path in sorted(_COMMANDS_DIR.glob("*.py")):
+        line_count = len(module_path.read_text(encoding="utf-8").splitlines())
+        if line_count > _MAX_LINES:
+            offenders[module_path.name] = line_count
+
+    assert not offenders, (
+        f"command modules exceed the {_MAX_LINES}-line limit: {offenders}. "
+        "Split cohesive responsibilities into a new module."
+    )


### PR DESCRIPTION
Part of the **"10 across the board"** plan (epic #212). Final structural workstream.

### Closes #207 — Code structure
- **Split `bump.py` 1040 → 698 LOC**: pure version math → `bump_versioning.py` (219), bump-my-version glue → `bump_engine.py` (242).
- Moved names are **re-imported into `bump.py`'s namespace**, so `from …bump import X` and `monkeypatch.setattr("…bump.X")` keep working. Only the `do_bump`/`get_configuration` patches (whose call sites moved into the engine) were repointed — **11 sites in one test file**.
- **Module-size gate**: `tests/test_module_size.py` — every `commands/*.py` ≤ 800 LOC.
- **Complexity gate**: enabled ruff **C901** (`max-complexity = 10`). Refactored the two violators with **no behavior change** — `bump_command` (12) via `_resolve_language` + `_finalize_bump`; `_execute_rollback` (11) via `_delete_rollback_tags`.
  - `PLR0913` intentionally **not** enabled (it fights typer's multi-option command signatures).
  - `C901` is ignored for `tests/` (elaborate mock setups), consistent with the existing per-file-ignores block — flagging in case you'd prefer to gate tests too (8 functions would need extracting).

### Closes #208 — Robustness
- `bump_engine.py` is now the **single module touching bump-my-version internals** (typed via a `BumpConfig` alias).
- `tests/test_bumpversion_contract.py` asserts the upstream `Config.pre_commit_hooks` field still exists and is list-typed — an upstream bump-my-version change now **fails loudly in CI** rather than at release time.

### Verification
`make test`: **439 passed, 100% coverage**. `make typecheck` (strict ty), `make fmt` (ruff incl. C901, interrogate 100%, bandit, uv-lock) all green.

This closes the last open structural issues; with #206/#209/#210 already merged, the only remaining plan item is #211 (Scorecard parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)