### PR TITLE
security: Scorecard workflow + CODEOWNERS + sync-ref bump (#211)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for rhiza-tools.
+#
+# Pull requests that modify matching paths request a review from a listed owner.
+# When a branch-protection ruleset enables `require_code_owner_review`, this also
+# feeds the OpenSSF Scorecard Code-Review and Branch-Protection checks.
+#
+# Listing the maintainer as the default owner documents review ownership; a
+# repository admin can still self-merge unless a ruleset removes that bypass.
+
+# Default owner for everything in the repository.
+*       @tschm

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -1,0 +1,78 @@
+# This file is part of the jebel-quant/rhiza repository
+# (https://github.com/jebel-quant/rhiza).
+#
+# Workflow: OSSF Scorecard
+#
+# Purpose: Run the OpenSSF Scorecard supply-chain security analysis and upload
+#          the results to GitHub code scanning. On public repositories the
+#          results are also published to the OpenSSF REST API, which powers
+#          the README badge and lets adopters verify the score independently.
+#          Set the SCORECARD_ENABLED repository variable to 'true' to
+#          force-enable on private repos, 'false' to disable, or leave unset
+#          for auto-detect (public repositories only).
+#
+# Trigger: Weekly schedule, pushes to main, branch-protection changes, and
+#          manual dispatch.
+
+name: "(RHIZA) SCORECARD"
+
+on:
+  # Re-evaluate when branch protection rules change (Scorecard's
+  # Branch-Protection check reads them).
+  branch_protection_rule:
+  schedule:
+    - cron: '34 2 * * 2'
+  push:
+    branches: [ "main", "master" ]
+  workflow_dispatch:
+
+# Cancel superseded in-progress runs of this workflow for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Least privilege by default; the job grants itself only what Scorecard needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    # Publishing results and the public score only work on public repositories.
+    if: |
+      vars.SCORECARD_ENABLED == 'true' ||
+      (vars.SCORECARD_ENABLED != 'false' && github.event.repository.visibility == 'public')
+    permissions:
+      # Needed to upload the SARIF results to code scanning.
+      security-events: write
+      # Needed to publish results to the OpenSSF REST API (badge support).
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the OpenSSF REST API so the score is externally
+          # verifiable and the README badge stays current (public repos only).
+          publish_results: true
+
+      - name: Upload Scorecard results artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload results to code scanning
+        uses: github/codeql-action/upload-sarif@v4.36.0
+        with:
+          sarif_file: results.sarif

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.18.8"
+ref: "v0.18.10"
 
 profiles:
   - github-project


### PR DESCRIPTION
Part of the **"10 across the board"** plan (epic #212). Final workstream.

### Context
rhiza-tools is a **sync consumer** of `jebel-quant/rhiza`, pinned at `v0.18.8`. The hardened release workflow (top-level `contents: read` + per-job perms) and the OpenSSF Scorecard workflow already live in rhiza's github bundle — they just hadn't reached rhiza-tools (both landed after `v0.18.8`). `rhiza_release.yml` is a **sync-managed** file, so hand-editing it would be clobbered on the next sync.

### This PR
- ✅ **CODEOWNERS** (`@tschm`) — not a bundle-managed file; feeds Scorecard Code-Review / Branch-Protection.
- ✅ **`rhiza_scorecard.yml`** — copied verbatim from the rhiza bundle so Scorecard analysis runs **now** (repo is public → auto-enabled) and matches what sync delivers (no drift).
- ✅ **Bump sync ref `v0.18.8 → v0.18.10`** in `.rhiza/template.yml` so the next sync pulls the hardened release workflow + the rest of the post-`v0.18.8` hardening (per-job permissions, harden-runner, etc.).

### Flows via the sync (not this diff)
- **Release-workflow hardening** (top-level read-only + per-job `permissions`, SHA/tag pins) — arrives when the sync workflow runs against `v0.18.10`. Editing the synced `rhiza_release.yml` directly would be overwritten, so it's intentionally not touched here.

### Maintainer decision (not imposed)
- **Branch-protection ruleset.** rhiza-tools has none and you self-merge. Adding one (like rhiza's `main-branch-protection.json`) would raise Scorecard Branch-Protection/Code-Review but needs either a second reviewer or retained admin bypass — same trade-off as the rhiza repo. Happy to add the ruleset JSON + docs if you want it.

### Verification
`make test`: 439 passed, 100% coverage. actionlint + all pre-commit hooks green.

Addresses #211 (leaving it open until the sync delivers the release-workflow hardening and you decide on the ruleset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)