### PR TITLE
Reach 10/10: repo-owned quality issues (#218, #222, #223, #224, #226)

### DIFF
--- a/docs/adr/0001-bump-my-version-adapter.md
+++ b/docs/adr/0001-bump-my-version-adapter.md
@@ -1,0 +1,41 @@
+# 0001 — Isolate bump-my-version behind an adapter
+
+- Status: Accepted
+- Deciders: rhiza-tools maintainers
+
+## Context
+
+The `bump` command drives [bump-my-version](https://github.com/callowayproject/bump-my-version)
+to rewrite version strings, commit, and tag. bump-my-version exposes internals
+we depend on directly: `bumpversion.bump.do_bump`, `bumpversion.config.get_configuration`,
+`bumpversion.ui.setup_logging`, the `Config` model (its `files_to_modify` and
+`pre_commit_hooks` fields), and the `BumpVersionError` exception hierarchy.
+
+These are not a stable public API. If they were referenced from many places, an
+upstream change would force edits scattered across the codebase, and we would
+likely discover the break only when a real release failed.
+
+## Decision
+
+All contact with bump-my-version internals lives in a single module,
+`rhiza_tools.commands.bump_engine`. Every other module goes through the helpers
+it exposes (`_build_configuration`, `_preflight_bump`, `_execute_bump`, …). The
+module is typed against bump-my-version's concrete `Config` (aliased
+`BumpConfig`) rather than `Any`, because `do_bump` requires that exact type, so
+the adapter must hold a real `Config` anyway — using it keeps the surface fully
+checked under strict `ty`.
+
+A contract test, `tests/test_bumpversion_contract.py`, pins the exact upstream
+surface the adapter relies on (the `pre_commit_hooks` and `files_to_modify`
+fields, and the importable `BumpVersionError` base). It inspects model fields
+only and never runs a full bump, so it is cheap and fails loudly at CI time if
+upstream renames or retypes anything.
+
+## Consequences
+
+- An upstream change is reconciled in exactly one module, and the contract test
+  flags it before it can corrupt a release.
+- Exception handling in the adapter is narrowed to the domains upstream actually
+  raises (`BumpVersionError`, plus `ValueError`/`OSError` for config loading)
+  rather than a blanket `except Exception` — see the adapter's inline notes.
+- The rest of the codebase never imports from `bumpversion.*`.

--- a/docs/adr/0002-changelog-in-bump-commit.md
+++ b/docs/adr/0002-changelog-in-bump-commit.md
@@ -1,0 +1,44 @@
+# 0002 — Fold the regenerated CHANGELOG into the bump commit
+
+- Status: Accepted
+- Deciders: rhiza-tools maintainers
+
+## Context
+
+When the project uses [git-cliff](https://git-cliff.org/) for changelogs, the
+`CHANGELOG.md` must be regenerated for each new version. The obvious approach —
+regenerate and push the changelog as its own commit on the default branch — has
+two problems in this project's setup:
+
+1. A separate push to the default branch is blocked by branch-protection
+   rulesets.
+2. It counts as an unreviewed change against the OpenSSF Scorecard Code-Review
+   check.
+
+## Decision
+
+`bump_engine._build_changelog_hooks` emits git-cliff commands as bump-my-version
+`pre_commit_hooks`:
+
+```
+uvx git-cliff --tag v<new_version> --output CHANGELOG.md
+git add CHANGELOG.md
+```
+
+bump-my-version runs these hooks and commits whatever is staged as part of the
+version-bump commit — the same mechanism already used to fold in `uv.lock`. The
+result is that the version bump, the lockfile, and the changelog land in a
+single commit and tag, with no separate push.
+
+The hooks are emitted only when the project is configured for git-cliff (a
+`cliff.toml` / `.cliff.toml` is present), so projects without changelog tooling
+are unaffected. The new version is passed with `--tag` because the release tag
+does not exist yet when the hooks run; otherwise git-cliff would file the new
+entries under "unreleased".
+
+## Consequences
+
+- One reviewable, atomic commit+tag per release; no default-branch side-push.
+- Compatible with branch protection and the Scorecard Code-Review check.
+- Behavior is gated on changelog tooling being present, so it is opt-in by
+  project configuration.

--- a/docs/adr/0003-quality-gates.md
+++ b/docs/adr/0003-quality-gates.md
@@ -1,0 +1,38 @@
+# 0003 — 100% coverage + strict `ty` + mutation testing
+
+- Status: Accepted
+- Deciders: rhiza-tools maintainers
+
+## Context
+
+`rhiza-tools` performs irreversible git operations (tagging, pushing, reverting)
+on behalf of users. A latent bug can corrupt a release. The codebase is small
+enough that a high bar is affordable, and we want regressions caught
+mechanically rather than by reviewer vigilance.
+
+## Decision
+
+Three independent gates run in CI, each catching a different failure class:
+
+1. **100% line coverage** (`--cov-fail-under=100`). Every line must be executed
+   by a test. This is a floor, not a goal — see gate 3 for why coverage alone is
+   insufficient.
+2. **Strict type checking** with `ty`, configured with
+   `error-on-warning = true` in `pyproject.toml`, so *warnings* fail the build,
+   not just hard errors. This keeps the type surface honest; the bump adapter
+   uses concrete upstream types rather than `Any` for the same reason
+   (see [ADR-0001](0001-bump-my-version-adapter.md)).
+3. **Mutation testing** (`mutmut`, the `mutation` make target / workflow).
+   Coverage proves lines *run*; mutation proves the tests would *fail* if the
+   code were wrong. This is what makes the 100% coverage number meaningful
+   rather than a line-execution ritual.
+
+100%-docstring coverage (`interrogate --fail-under 100`) is enforced alongside
+these for the public surface.
+
+## Consequences
+
+- New code must arrive with tests that both cover and *constrain* it.
+- Coverage is never chased for its own sake; tests assert behavior. This is
+  itself enforced — see [ADR-0004](0004-structural-meta-tests.md).
+- The bar is sustainable specifically because the package is small and focused.

--- a/docs/adr/0004-structural-meta-tests.md
+++ b/docs/adr/0004-structural-meta-tests.md
@@ -1,0 +1,35 @@
+# 0004 — Enforce structure with meta-tests, not convention
+
+- Status: Accepted
+- Deciders: rhiza-tools maintainers
+
+## Context
+
+Two structural properties tend to erode quietly over a project's life:
+
+- Command modules accrete code until they are hard to navigate.
+- Test suites accumulate "coverage bucket" files whose only purpose is to
+  execute lines for the coverage number, divorced from behavior.
+
+Conventions and code review catch these inconsistently. We prefer guarantees
+that fail a build.
+
+## Decision
+
+Encode the structural rules as ordinary tests that run with the suite:
+
+- **`tests/test_module_size.py`** — every `src/rhiza_tools/commands/*.py` must
+  stay at or below a line ceiling (currently 750; see
+  [ADR-0005](0005-command-module-split.md)). Growth must be split into a new
+  module rather than accreted.
+- **`tests/test_suite_hygiene.py`** — there must be no `test_coverage*.py`
+  catch-all bucket, and no test module may declare its purpose as achieving a
+  coverage number. Coverage honesty is the job of mutation testing
+  (see [ADR-0003](0003-quality-gates.md)), not of line-chasing files.
+
+## Consequences
+
+- The "keep modules small" and "tests assert behavior" rules are enforced, not
+  hoped for; violations fail CI with an actionable message.
+- The ceiling is a deliberate, reviewable number that moves only with an
+  accompanying decision.

--- a/docs/adr/0005-command-module-split.md
+++ b/docs/adr/0005-command-module-split.md
@@ -1,0 +1,41 @@
+# 0005 — Split large command modules by responsibility
+
+- Status: Accepted
+- Deciders: rhiza-tools maintainers
+
+## Context
+
+Command modules naturally mix three concerns: the Typer command surface and
+orchestration, version/bump logic, and git plumbing. Left together they grow
+past the size at which a file is easy to reason about (the original `bump.py`
+crossed this line in #207).
+
+## Decision
+
+When a command module grows large, extract a cohesive responsibility into a
+sibling module and **re-export** the moved names from the original module so the
+public import surface — and existing tests — are unchanged. The established
+pattern:
+
+| Command | Surface / orchestration | Extracted module(s) |
+| ------- | ----------------------- | ------------------- |
+| `bump` | `bump.py` | `bump_versioning.py`, `bump_engine.py` (the adapter, [ADR-0001](0001-bump-my-version-adapter.md)) |
+| `release` | `release.py` | `release_versioning.py` (bump-type resolution) |
+| `rollback` | `rollback.py` | `rollback_git.py` (git tag/commit plumbing) |
+
+Because the helpers are re-exported, callers and tests continue to import
+`release.<helper>` / `rollback.<helper>`. When a moved function looks up a
+dependency in its **new** module's namespace, the corresponding test patch
+target moves with it (e.g. `release_versioning.bump_command`,
+`rollback_git.run_git_command`).
+
+The [`test_module_size`](0004-structural-meta-tests.md) gate enforces the
+ceiling that triggers this; after the #223 split the largest command module is
+~700 lines and the gate is set to 750.
+
+## Consequences
+
+- Each module has a single clear responsibility and stays navigable.
+- The re-export convention keeps refactors non-breaking for importers.
+- Splitting interacts with the test suite's module-namespace patching: moving
+  code requires moving the patch target to where the dependency now resolves.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,23 @@
+# Architecture Decision Records
+
+This directory records the **non-obvious** architectural decisions behind
+`rhiza-tools` — the ones whose rationale is not self-evident from the code and
+would otherwise live only in commit messages or a maintainer's head.
+
+We use a lightweight [MADR](https://adr.github.io/madr/)-style format. Each
+record is immutable once accepted: to change a decision, add a new ADR that
+supersedes the old one (and update the old one's status), rather than editing
+history.
+
+See [the decision process](../development/DECISIONS.md) for when an ADR is
+required and how to add one.
+
+## Index
+
+| ADR | Title | Status |
+| --- | ----- | ------ |
+| [0001](0001-bump-my-version-adapter.md) | Isolate bump-my-version behind an adapter | Accepted |
+| [0002](0002-changelog-in-bump-commit.md) | Fold the regenerated CHANGELOG into the bump commit | Accepted |
+| [0003](0003-quality-gates.md) | 100% coverage + strict `ty` + mutation testing | Accepted |
+| [0004](0004-structural-meta-tests.md) | Enforce structure with meta-tests, not convention | Accepted |
+| [0005](0005-command-module-split.md) | Split large command modules by responsibility | Accepted |

--- a/docs/development/DECISIONS.md
+++ b/docs/development/DECISIONS.md
@@ -1,0 +1,43 @@
+# Recording architecture decisions
+
+This project records significant, non-obvious architectural decisions as
+**Architecture Decision Records (ADRs)** under [`docs/adr/`](../adr/README.md).
+This page explains *when* to write one and *how*.
+
+## When an ADR is required
+
+Write an ADR when a change involves a decision whose rationale is not obvious
+from the code and would otherwise be lost. Typical triggers:
+
+- Depending on a third-party library's internals or making an assumption about
+  its behavior (e.g. the bump-my-version adapter).
+- Introducing or changing a quality gate (coverage, typing, mutation, size,
+  hygiene) or its threshold.
+- A structural convention other contributors are expected to follow (e.g. how
+  large modules are split).
+- A non-local trade-off: choosing one approach over a reasonable alternative for
+  reasons that future readers would otherwise have to reverse-engineer.
+
+You do **not** need an ADR for routine bug fixes, dependency bumps, or changes
+whose intent is clear from the diff and its tests.
+
+## How to add one
+
+1. Copy the structure of an existing record in [`docs/adr/`](../adr/README.md).
+   We use a lightweight [MADR](https://adr.github.io/madr/) style: **Context**,
+   **Decision**, **Consequences**, plus a `Status` line.
+2. Number it sequentially (`000N-short-kebab-title.md`).
+3. Add a row to the table in [`docs/adr/README.md`](../adr/README.md).
+4. If the decision changes an earlier one, add a new ADR that supersedes it and
+   set the old record's status to `Superseded by 000N` — ADRs are immutable once
+   accepted; we add, we don't rewrite.
+
+## Repo-owned vs. template-synced files
+
+Some governance and config files (for example `CONTRIBUTING.md`, `ruff.toml`,
+the `rhiza_*.yml` workflows, and `.pre-commit-config.yaml`) are **synced from
+the [Rhiza template](https://github.com/Jebel-Quant/rhiza)** and are listed in
+`.rhiza/template.lock`. Editing them here is reverted on the next sync — changes
+to those belong upstream. Everything under `src/`, `tests/`, `docs/adr/`, this
+`docs/development/DECISIONS.md`, `pyproject.toml`, and `mkdocs.yml` is repo-owned
+and edited here directly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,3 +20,12 @@ nav:
     - generate-coverage-badge: commands/generate_coverage_badge.md
     - version-matrix: commands/version_matrix.md
     - analyze-benchmarks: commands/analyze_benchmarks.md
+  - Architecture Decisions:
+    - Overview: adr/README.md
+    - 0001 bump-my-version adapter: adr/0001-bump-my-version-adapter.md
+    - 0002 changelog in bump commit: adr/0002-changelog-in-bump-commit.md
+    - 0003 quality gates: adr/0003-quality-gates.md
+    - 0004 structural meta-tests: adr/0004-structural-meta-tests.md
+    - 0005 command module split: adr/0005-command-module-split.md
+  - Contributing:
+    - Recording decisions: development/DECISIONS.md

--- a/src/rhiza_tools/commands/bump_engine.py
+++ b/src/rhiza_tools/commands/bump_engine.py
@@ -15,15 +15,19 @@ from typing import Any
 import typer
 from bumpversion.bump import do_bump
 from bumpversion.config import get_configuration
+from bumpversion.config.models import Config as BumpConfig
+from bumpversion.exceptions import BumpVersionError
 from bumpversion.ui import setup_logging
 from loguru import logger
 
 from rhiza_tools import console
 from rhiza_tools.config import CONFIG_FILENAME
 
-# bump-my-version's configuration object (``bumpversion.config.models.Config``).
-# Kept as ``Any`` so static typing stays permissive while documenting intent.
-BumpConfig = Any  # bump-my-version's bumpversion.config.models.Config
+# ``BumpConfig`` is bump-my-version's concrete ``bumpversion.config.models.Config``.
+# It is used directly (rather than ``Any`` or a structural Protocol) because
+# ``do_bump`` requires this exact type, so the adapter must hold a real ``Config``
+# anyway. Importing it keeps every helper below fully typed under strict ``ty``.
+# The companion ``tests/test_bumpversion_contract.py`` pins the attributes used.
 
 
 def _build_configuration(
@@ -56,7 +60,10 @@ def _build_configuration(
 
     try:
         config = get_configuration(config_file=config_path, **overrides)
-    except Exception as e:
+    # Config loading fails in a few distinct ways: a malformed TOML file raises
+    # tomlkit's ``ParseError`` (a ``ValueError``), bump-my-version validation
+    # raises ``BumpVersionError``, and an unreadable file raises ``OSError``.
+    except (BumpVersionError, ValueError, OSError) as e:
         console.error(f"Failed to load bumpversion configuration: {e}")
         console.error(f"Check your bumpversion config at: {config_path}")
         console.error("Ensure the [tool.bumpversion] section is valid TOML with correct version patterns.")
@@ -112,8 +119,10 @@ def _get_files_to_modify(config: BumpConfig) -> list[Path]:
     files = []
     if hasattr(config, "files_to_modify"):
         for file_config in config.files_to_modify:
-            if hasattr(file_config, "filename"):
-                files.append(Path(file_config.filename))
+            # ``filename`` is typed ``str | None`` upstream; skip unnamed entries.
+            filename = file_config.filename
+            if filename:
+                files.append(Path(filename))
     return files
 
 
@@ -144,7 +153,8 @@ def _show_file_changes(file_path: Path, current_version: str, new_version: str) 
                 console.info(f"    Line {line_num}:")
                 console.info(f"      {typer.style('-', fg=typer.colors.RED)} {old_line.strip()}")
                 console.info(f"      {typer.style('+', fg=typer.colors.GREEN)} {new_line.strip()}")
-    except Exception as e:
+    except OSError as e:
+        # Previewing is best-effort; an unreadable file should not abort the bump.
         logger.debug(f"Could not preview changes for {file_path}: {e}")
 
 
@@ -200,7 +210,9 @@ def _preflight_bump(new_version_str: str, config: BumpConfig, config_path: Path)
             config_file=config_path,
             dry_run=True,
         )
-    except Exception as e:
+    # do_bump surfaces version/format/hook problems as ``BumpVersionError`` and
+    # file-access problems as ``OSError``; both mean the bump cannot proceed.
+    except (BumpVersionError, OSError) as e:
         console.error(f"Preflight validation failed: {e}")
         console.error("No changes were made.")
         raise typer.Exit(code=1) from None
@@ -231,7 +243,9 @@ def _execute_bump(new_version_str: str, config: BumpConfig, config_path: Path, d
             config_file=config_path,
             dry_run=dry_run,
         )
-    except Exception as e:
+    # do_bump surfaces version/format/hook problems as ``BumpVersionError`` and
+    # file-access problems as ``OSError``; both can leave files partially edited.
+    except (BumpVersionError, OSError) as e:
         console.error(f"bump-my-version failed: {e}")
         if not dry_run:
             console.error("Files may have been partially modified. To recover:")

--- a/src/rhiza_tools/commands/release.py
+++ b/src/rhiza_tools/commands/release.py
@@ -26,26 +26,32 @@ from pathlib import Path
 
 import semver
 import typer
-from loguru import logger
 
 from rhiza_tools import console
 from rhiza_tools.commands._shared import (
-    NON_INTERACTIVE_ERRORS,
     get_latest_remote_version,
     run_git_command,
 )
 from rhiza_tools.commands.bump import (
-    BumpOptions,
     Language,
-    _resolve_bump_baseline,
-    bump_command,
-    get_bumped_version_from_type,
     get_current_version,
-    get_interactive_bump_type,
 )
 
-# Combined tuple for catching both typer.Exit and non-interactive environment errors.
-_EXIT_OR_NON_INTERACTIVE: tuple[type[BaseException], ...] = (typer.Exit, *NON_INTERACTIVE_ERRORS)
+# Bump-type resolution lives in release_versioning; re-exported here so the
+# public import surface (and existing tests) keep using ``release.<helper>``.
+from rhiza_tools.commands.release_versioning import (
+    _get_bump_type_interactively,
+    _perform_version_bump,
+)
+from rhiza_tools.commands.release_versioning import (
+    _resolve_explicit_bump_type as _resolve_explicit_bump_type,
+)
+from rhiza_tools.commands.release_versioning import (
+    _resolve_interactive_prompt as _resolve_interactive_prompt,
+)
+from rhiza_tools.commands.release_versioning import (
+    _resolve_with_bump_flag as _resolve_with_bump_flag,
+)
 
 
 def check_clean_working_tree() -> None:
@@ -231,156 +237,6 @@ def push_tag(tag: str, dry_run: bool = False, non_interactive: bool = False) -> 
 
     if repo_path:
         console.info(f"Monitor progress at: https://github.com/{repo_path}/actions")
-
-
-def _get_bump_type_interactively(
-    non_interactive: bool, bump_type: str | None, dry_run: bool, with_bump: bool = False, *, language: Language
-) -> tuple[bool, str | None]:
-    """Get bump version interactively or from parameters.
-
-    Uses the same interactive selection as the bump command to ensure consistent
-    behavior between ``rhiza-tools bump`` and ``rhiza-tools release --with-bump``.
-
-    Args:
-        non_interactive: If True, skip interactive prompts.
-        bump_type: Explicit bump type provided (e.g., "MAJOR", "MINOR", "PATCH").
-        dry_run: If True, the bump will be simulated (handled by caller).
-        with_bump: If True, enable interactive bump selection directly.
-        language: The programming language for version reading.
-
-    Returns:
-        Tuple of (should_bump, new_version_string). The version string is the
-        explicit new version (not a bump type keyword).
-    """
-    if bump_type:
-        return _resolve_explicit_bump_type(bump_type, language)
-
-    if with_bump:
-        return _resolve_with_bump_flag(non_interactive, language)
-
-    if not non_interactive:
-        return _resolve_interactive_prompt(language)
-
-    # Non-interactive without --with-bump or --bump: no bump
-    return False, None
-
-
-def _resolve_explicit_bump_type(bump_type: str, language: Language) -> tuple[bool, str | None]:
-    """Resolve version from an explicitly provided bump type.
-
-    Args:
-        bump_type: The bump type keyword (e.g., "MAJOR", "MINOR", "PATCH").
-        language: The programming language for version reading.
-
-    Returns:
-        Tuple of (True, new_version_string).
-
-    Raises:
-        typer.Exit: If the current version is invalid or the bump type is unsupported.
-    """
-    current_version_str = _resolve_bump_baseline(get_current_version(language))
-    try:
-        current_semver = semver.Version.parse(current_version_str)
-    except ValueError:
-        console.error(f"Invalid semantic version: {current_version_str}")
-        raise typer.Exit(code=1) from None
-    new_version = get_bumped_version_from_type(current_semver, bump_type.lower())
-    if not new_version:
-        console.error(f"Invalid bump type: {bump_type}")
-        raise typer.Exit(code=1)
-    return True, new_version
-
-
-def _resolve_with_bump_flag(non_interactive: bool, language: Language) -> tuple[bool, str | None]:
-    """Resolve version when --with-bump flag is set.
-
-    In non-interactive mode defaults to patch; otherwise prompts interactively.
-
-    Args:
-        non_interactive: If True, default to a patch bump.
-        language: The programming language for version reading.
-
-    Returns:
-        Tuple of (should_bump, new_version_string).
-    """
-    if non_interactive:
-        console.warning("--with-bump in non-interactive mode without --bump type, defaulting to patch")
-        current_version_str = _resolve_bump_baseline(get_current_version(language))
-        current_semver = semver.Version.parse(current_version_str)
-        return True, str(current_semver.bump_patch())
-
-    current_version_str = _resolve_bump_baseline(get_current_version(language))
-    try:
-        new_version = get_interactive_bump_type(current_version_str)
-    except _EXIT_OR_NON_INTERACTIVE:
-        return False, None
-    return True, new_version
-
-
-def _resolve_interactive_prompt(language: Language) -> tuple[bool, str | None]:
-    """Prompt the user interactively whether to bump before releasing.
-
-    Args:
-        language: The programming language for version reading.
-
-    Returns:
-        Tuple of (should_bump, new_version_string).
-    """
-    import questionary as qs
-
-    try:
-        should_bump = qs.confirm(
-            "Would you like to bump the version before releasing?",
-            default=False,
-        ).ask()
-    except NON_INTERACTIVE_ERRORS:
-        logger.debug("Running in non-interactive environment")
-        return False, None
-
-    if not should_bump:
-        return False, None
-
-    current_version_str = _resolve_bump_baseline(get_current_version(language))
-    try:
-        new_version = get_interactive_bump_type(current_version_str)
-    except _EXIT_OR_NON_INTERACTIVE:
-        return False, None
-    return True, new_version
-
-
-def _perform_version_bump(new_version: str, dry_run: bool, language: Language, config: Path | None = None) -> str:
-    """Perform version bump with validation.
-
-    Args:
-        new_version: The explicit new version string to bump to.
-        dry_run: If True, only simulate the bump.
-        language: The programming language for the bump.
-        config: Optional path to the .cfg.toml bumpversion config file.
-
-    Returns:
-        The new version string.
-
-    Raises:
-        typer.Exit: If the bump operation fails.
-    """
-    console.info(f"Bumping version to: {new_version}")
-
-    bump_command(
-        BumpOptions(
-            version=new_version,
-            dry_run=dry_run,
-            commit=True,
-            push=False,  # Don't push yet, we'll do it after tagging
-            allow_dirty=False,
-            language=language,
-            config=config,
-        )
-    )
-
-    if dry_run:
-        console.info("[DRY-RUN] Version would be bumped before release")
-
-    return new_version
 
 
 def _validate_tag_state(tag: str, current_version: str) -> None:

--- a/src/rhiza_tools/commands/release_versioning.py
+++ b/src/rhiza_tools/commands/release_versioning.py
@@ -1,0 +1,179 @@
+"""Bump-type resolution for the release command.
+
+The release command can optionally bump the version before tagging. Working out
+*which* version to bump to — from an explicit ``--bump`` type, the ``--with-bump``
+flag, or an interactive prompt — is a self-contained concern with no git
+plumbing, so it lives here rather than in ``release.py``. ``release.py``
+re-exports these helpers, so the public import surface is unchanged.
+"""
+
+from pathlib import Path
+
+import semver
+import typer
+from loguru import logger
+
+from rhiza_tools import console
+from rhiza_tools.commands._shared import NON_INTERACTIVE_ERRORS
+from rhiza_tools.commands.bump import (
+    BumpOptions,
+    Language,
+    _resolve_bump_baseline,
+    bump_command,
+    get_bumped_version_from_type,
+    get_current_version,
+    get_interactive_bump_type,
+)
+
+# Combined tuple for catching both typer.Exit and non-interactive environment errors.
+_EXIT_OR_NON_INTERACTIVE: tuple[type[BaseException], ...] = (typer.Exit, *NON_INTERACTIVE_ERRORS)
+
+
+def _get_bump_type_interactively(
+    non_interactive: bool, bump_type: str | None, dry_run: bool, with_bump: bool = False, *, language: Language
+) -> tuple[bool, str | None]:
+    """Get bump version interactively or from parameters.
+
+    Uses the same interactive selection as the bump command to ensure consistent
+    behavior between ``rhiza-tools bump`` and ``rhiza-tools release --with-bump``.
+
+    Args:
+        non_interactive: If True, skip interactive prompts.
+        bump_type: Explicit bump type provided (e.g., "MAJOR", "MINOR", "PATCH").
+        dry_run: If True, the bump will be simulated (handled by caller).
+        with_bump: If True, enable interactive bump selection directly.
+        language: The programming language for version reading.
+
+    Returns:
+        Tuple of (should_bump, new_version_string). The version string is the
+        explicit new version (not a bump type keyword).
+    """
+    if bump_type:
+        return _resolve_explicit_bump_type(bump_type, language)
+
+    if with_bump:
+        return _resolve_with_bump_flag(non_interactive, language)
+
+    if not non_interactive:
+        return _resolve_interactive_prompt(language)
+
+    # Non-interactive without --with-bump or --bump: no bump
+    return False, None
+
+
+def _resolve_explicit_bump_type(bump_type: str, language: Language) -> tuple[bool, str | None]:
+    """Resolve version from an explicitly provided bump type.
+
+    Args:
+        bump_type: The bump type keyword (e.g., "MAJOR", "MINOR", "PATCH").
+        language: The programming language for version reading.
+
+    Returns:
+        Tuple of (True, new_version_string).
+
+    Raises:
+        typer.Exit: If the current version is invalid or the bump type is unsupported.
+    """
+    current_version_str = _resolve_bump_baseline(get_current_version(language))
+    try:
+        current_semver = semver.Version.parse(current_version_str)
+    except ValueError:
+        console.error(f"Invalid semantic version: {current_version_str}")
+        raise typer.Exit(code=1) from None
+    new_version = get_bumped_version_from_type(current_semver, bump_type.lower())
+    if not new_version:
+        console.error(f"Invalid bump type: {bump_type}")
+        raise typer.Exit(code=1)
+    return True, new_version
+
+
+def _resolve_with_bump_flag(non_interactive: bool, language: Language) -> tuple[bool, str | None]:
+    """Resolve version when --with-bump flag is set.
+
+    In non-interactive mode defaults to patch; otherwise prompts interactively.
+
+    Args:
+        non_interactive: If True, default to a patch bump.
+        language: The programming language for version reading.
+
+    Returns:
+        Tuple of (should_bump, new_version_string).
+    """
+    if non_interactive:
+        console.warning("--with-bump in non-interactive mode without --bump type, defaulting to patch")
+        current_version_str = _resolve_bump_baseline(get_current_version(language))
+        current_semver = semver.Version.parse(current_version_str)
+        return True, str(current_semver.bump_patch())
+
+    current_version_str = _resolve_bump_baseline(get_current_version(language))
+    try:
+        new_version = get_interactive_bump_type(current_version_str)
+    except _EXIT_OR_NON_INTERACTIVE:
+        return False, None
+    return True, new_version
+
+
+def _resolve_interactive_prompt(language: Language) -> tuple[bool, str | None]:
+    """Prompt the user interactively whether to bump before releasing.
+
+    Args:
+        language: The programming language for version reading.
+
+    Returns:
+        Tuple of (should_bump, new_version_string).
+    """
+    import questionary as qs
+
+    try:
+        should_bump = qs.confirm(
+            "Would you like to bump the version before releasing?",
+            default=False,
+        ).ask()
+    except NON_INTERACTIVE_ERRORS:
+        logger.debug("Running in non-interactive environment")
+        return False, None
+
+    if not should_bump:
+        return False, None
+
+    current_version_str = _resolve_bump_baseline(get_current_version(language))
+    try:
+        new_version = get_interactive_bump_type(current_version_str)
+    except _EXIT_OR_NON_INTERACTIVE:
+        return False, None
+    return True, new_version
+
+
+def _perform_version_bump(new_version: str, dry_run: bool, language: Language, config: Path | None = None) -> str:
+    """Perform version bump with validation.
+
+    Args:
+        new_version: The explicit new version string to bump to.
+        dry_run: If True, only simulate the bump.
+        language: The programming language for the bump.
+        config: Optional path to the .cfg.toml bumpversion config file.
+
+    Returns:
+        The new version string.
+
+    Raises:
+        typer.Exit: If the bump operation fails.
+    """
+    console.info(f"Bumping version to: {new_version}")
+
+    bump_command(
+        BumpOptions(
+            version=new_version,
+            dry_run=dry_run,
+            commit=True,
+            push=False,  # Don't push yet, we'll do it after tagging
+            allow_dirty=False,
+            language=language,
+            config=config,
+        )
+    )
+
+    if dry_run:
+        console.info("[DRY-RUN] Version would be bumped before release")
+
+    return new_version

--- a/src/rhiza_tools/commands/rollback.py
+++ b/src/rhiza_tools/commands/rollback.py
@@ -36,6 +36,18 @@ from rhiza_tools.commands._shared import (
 )
 from rhiza_tools.commands.release import check_tag_exists
 
+# Git tag/commit plumbing lives in rollback_git; re-exported here so callers and
+# existing tests keep importing ``rollback.<helper>``.
+from rhiza_tools.commands.rollback_git import (
+    _delete_local_tag,
+    _delete_remote_tag,
+    _get_previous_version_from_tags,
+    _get_tag_commit,
+    _get_tag_details,
+    _is_bump_commit,
+    _revert_bump_commit,
+)
+
 
 @dataclass
 class RollbackOptions:
@@ -119,186 +131,6 @@ def _select_tag_interactively(tags: list[str]) -> str:
 
     # Extract tag name from choice string "v1.2.3 (local, remote)"
     return str(choice).split(" (")[0]
-
-
-def _get_tag_commit(tag: str) -> str | None:
-    """Get the commit hash that a tag points to.
-
-    Args:
-        tag: The tag name.
-
-    Returns:
-        The commit hash, or None if the tag doesn't exist locally.
-    """
-    result = run_git_command(["git", "rev-list", "-n", "1", tag], check=False)
-    if result.returncode != 0:
-        return None
-    return result.stdout.strip()
-
-
-def _get_tag_details(tag: str) -> dict[str, str]:
-    """Get details about a tag.
-
-    Args:
-        tag: The tag name.
-
-    Returns:
-        Dictionary with commit hash, date, and message.
-    """
-    details: dict[str, str] = {}
-    result = run_git_command(
-        ["git", "show", "-s", "--format=%H|%ci|%s", tag],
-        check=False,
-    )
-    if result.returncode == 0 and result.stdout.strip():
-        parts = result.stdout.strip().split("|")
-        if len(parts) == 3:
-            details["hash"] = parts[0]
-            details["date"] = parts[1]
-            details["message"] = parts[2]
-    return details
-
-
-def _is_bump_commit(tag: str) -> bool:
-    """Check if the commit the tag points to looks like a bump commit.
-
-    Bump commits typically have messages like "Bump version: X.Y.Z → A.B.C"
-    or contain version-related keywords.
-
-    Args:
-        tag: The tag name.
-
-    Returns:
-        True if the tag's commit appears to be a bump commit.
-    """
-    result = run_git_command(
-        ["git", "log", "-1", "--format=%s", tag],
-        check=False,
-    )
-    if result.returncode != 0:
-        return False
-
-    message = result.stdout.strip().lower()
-    bump_keywords = ["bump version", "bump:", "version bump", "release version", "chore: bump"]
-    return any(keyword in message for keyword in bump_keywords)
-
-
-def _get_previous_version_from_tags(current_tag: str) -> str | None:
-    """Find the previous version tag before the given tag.
-
-    Args:
-        current_tag: The current tag being rolled back.
-
-    Returns:
-        The previous tag name, or None if no previous tag exists.
-    """
-    result = run_git_command(
-        ["git", "tag", "--sort=-version:refname", "-l", "v*"],
-        check=False,
-    )
-    if result.returncode != 0 or not result.stdout.strip():
-        return None
-
-    tags = [t.strip() for t in result.stdout.strip().split("\n") if t.strip()]
-
-    try:
-        idx = tags.index(current_tag)
-        if idx + 1 < len(tags):
-            return tags[idx + 1]
-    except ValueError:
-        pass
-
-    return None
-
-
-def _delete_local_tag(tag: str, dry_run: bool) -> bool:
-    """Delete a tag from the local repository.
-
-    Args:
-        tag: The tag name to delete.
-        dry_run: If True, only simulate deletion.
-
-    Returns:
-        True if deletion succeeded (or would succeed in dry-run).
-    """
-    if dry_run:
-        console.info(f"[DRY-RUN] Would delete local tag: {tag}")
-        return True
-
-    result = run_git_command(["git", "tag", "-d", tag], check=False)
-    if result.returncode == 0:
-        console.success(f"Deleted local tag: {tag}")
-        return True
-    else:
-        console.error(f"Failed to delete local tag: {tag}")
-        console.error(f"Error: {result.stderr}")
-        return False
-
-
-def _delete_remote_tag(tag: str, dry_run: bool) -> bool:
-    """Delete a tag from the remote repository.
-
-    Args:
-        tag: The tag name to delete.
-        dry_run: If True, only simulate deletion.
-
-    Returns:
-        True if deletion succeeded (or would succeed in dry-run).
-    """
-    if dry_run:
-        console.info(f"[DRY-RUN] Would delete remote tag: {tag}")
-        return True
-
-    console.info(f"Deleting remote tag: {tag}...")
-    result = run_git_command(
-        ["git", "push", "origin", f":refs/tags/{tag}"],
-        check=False,
-    )
-    if result.returncode == 0:
-        console.success(f"Deleted remote tag: {tag}")
-        return True
-    else:
-        console.error(f"Failed to delete remote tag: {tag}")
-        console.error(f"Error: {result.stderr}")
-        return False
-
-
-def _revert_bump_commit(commit_hash: str, dry_run: bool) -> bool:
-    """Revert the version bump commit.
-
-    Creates a new revert commit rather than rewriting history, making
-    this safe even when the commit has been pushed to remote.
-
-    Args:
-        commit_hash: The commit hash to revert.
-        dry_run: If True, only simulate the revert.
-
-    Returns:
-        True if revert succeeded (or would succeed in dry-run).
-    """
-    if dry_run:
-        result = run_git_command(
-            ["git", "log", "-1", "--format=%s", commit_hash],
-            check=False,
-        )
-        commit_msg = result.stdout.strip() if result.returncode == 0 else "unknown"
-        console.info(f"[DRY-RUN] Would revert commit {commit_hash[:8]}: {commit_msg}")
-        return True
-
-    console.info(f"Reverting bump commit {commit_hash[:8]}...")
-    result = run_git_command(
-        ["git", "revert", "--no-edit", commit_hash],
-        check=False,
-    )
-    if result.returncode == 0:
-        console.success(f"Reverted bump commit: {commit_hash[:8]}")
-        return True
-    else:
-        console.error(f"Failed to revert commit {commit_hash[:8]}")
-        console.error(f"Error: {result.stderr}")
-        console.error("You may need to resolve conflicts manually:")
-        console.error(f"  git revert {commit_hash[:8]}")
-        return False
 
 
 def _push_revert(dry_run: bool, non_interactive: bool) -> bool:

--- a/src/rhiza_tools/commands/rollback_git.py
+++ b/src/rhiza_tools/commands/rollback_git.py
@@ -1,0 +1,192 @@
+"""Git tag and commit plumbing for the rollback command.
+
+These helpers wrap the read-only git queries (tag commit, details, history) and
+the tag/commit mutations (delete local/remote tag, revert) that rollback needs.
+They contain no interactive prompts, so they live apart from the orchestration
+and UI in ``rollback.py``, which re-exports them for its callers and tests.
+"""
+
+from __future__ import annotations
+
+from rhiza_tools import console
+from rhiza_tools.commands._shared import run_git_command
+
+
+def _get_tag_commit(tag: str) -> str | None:
+    """Get the commit hash that a tag points to.
+
+    Args:
+        tag: The tag name.
+
+    Returns:
+        The commit hash, or None if the tag doesn't exist locally.
+    """
+    result = run_git_command(["git", "rev-list", "-n", "1", tag], check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _get_tag_details(tag: str) -> dict[str, str]:
+    """Get details about a tag.
+
+    Args:
+        tag: The tag name.
+
+    Returns:
+        Dictionary with commit hash, date, and message.
+    """
+    details: dict[str, str] = {}
+    result = run_git_command(
+        ["git", "show", "-s", "--format=%H|%ci|%s", tag],
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        parts = result.stdout.strip().split("|")
+        if len(parts) == 3:
+            details["hash"] = parts[0]
+            details["date"] = parts[1]
+            details["message"] = parts[2]
+    return details
+
+
+def _is_bump_commit(tag: str) -> bool:
+    """Check if the commit the tag points to looks like a bump commit.
+
+    Bump commits typically have messages like "Bump version: X.Y.Z → A.B.C"
+    or contain version-related keywords.
+
+    Args:
+        tag: The tag name.
+
+    Returns:
+        True if the tag's commit appears to be a bump commit.
+    """
+    result = run_git_command(
+        ["git", "log", "-1", "--format=%s", tag],
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+
+    message = result.stdout.strip().lower()
+    bump_keywords = ["bump version", "bump:", "version bump", "release version", "chore: bump"]
+    return any(keyword in message for keyword in bump_keywords)
+
+
+def _get_previous_version_from_tags(current_tag: str) -> str | None:
+    """Find the previous version tag before the given tag.
+
+    Args:
+        current_tag: The current tag being rolled back.
+
+    Returns:
+        The previous tag name, or None if no previous tag exists.
+    """
+    result = run_git_command(
+        ["git", "tag", "--sort=-version:refname", "-l", "v*"],
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+
+    tags = [t.strip() for t in result.stdout.strip().split("\n") if t.strip()]
+
+    try:
+        idx = tags.index(current_tag)
+        if idx + 1 < len(tags):
+            return tags[idx + 1]
+    except ValueError:
+        pass
+
+    return None
+
+
+def _delete_local_tag(tag: str, dry_run: bool) -> bool:
+    """Delete a tag from the local repository.
+
+    Args:
+        tag: The tag name to delete.
+        dry_run: If True, only simulate deletion.
+
+    Returns:
+        True if deletion succeeded (or would succeed in dry-run).
+    """
+    if dry_run:
+        console.info(f"[DRY-RUN] Would delete local tag: {tag}")
+        return True
+
+    result = run_git_command(["git", "tag", "-d", tag], check=False)
+    if result.returncode == 0:
+        console.success(f"Deleted local tag: {tag}")
+        return True
+    else:
+        console.error(f"Failed to delete local tag: {tag}")
+        console.error(f"Error: {result.stderr}")
+        return False
+
+
+def _delete_remote_tag(tag: str, dry_run: bool) -> bool:
+    """Delete a tag from the remote repository.
+
+    Args:
+        tag: The tag name to delete.
+        dry_run: If True, only simulate deletion.
+
+    Returns:
+        True if deletion succeeded (or would succeed in dry-run).
+    """
+    if dry_run:
+        console.info(f"[DRY-RUN] Would delete remote tag: {tag}")
+        return True
+
+    console.info(f"Deleting remote tag: {tag}...")
+    result = run_git_command(
+        ["git", "push", "origin", f":refs/tags/{tag}"],
+        check=False,
+    )
+    if result.returncode == 0:
+        console.success(f"Deleted remote tag: {tag}")
+        return True
+    else:
+        console.error(f"Failed to delete remote tag: {tag}")
+        console.error(f"Error: {result.stderr}")
+        return False
+
+
+def _revert_bump_commit(commit_hash: str, dry_run: bool) -> bool:
+    """Revert the version bump commit.
+
+    Creates a new revert commit rather than rewriting history, making
+    this safe even when the commit has been pushed to remote.
+
+    Args:
+        commit_hash: The commit hash to revert.
+        dry_run: If True, only simulate the revert.
+
+    Returns:
+        True if revert succeeded (or would succeed in dry-run).
+    """
+    if dry_run:
+        result = run_git_command(
+            ["git", "log", "-1", "--format=%s", commit_hash],
+            check=False,
+        )
+        commit_msg = result.stdout.strip() if result.returncode == 0 else "unknown"
+        console.info(f"[DRY-RUN] Would revert commit {commit_hash[:8]}: {commit_msg}")
+        return True
+
+    console.info(f"Reverting bump commit {commit_hash[:8]}...")
+    result = run_git_command(
+        ["git", "revert", "--no-edit", commit_hash],
+        check=False,
+    )
+    if result.returncode == 0:
+        console.success(f"Reverted bump commit: {commit_hash[:8]}")
+        return True
+    else:
+        console.error(f"Failed to revert commit {commit_hash[:8]}")
+        console.error(f"Error: {result.stderr}")
+        console.error("You may need to resolve conflicts manually:")
+        console.error(f"  git revert {commit_hash[:8]}")
+        return False

--- a/tests/test_bump_command.py
+++ b/tests/test_bump_command.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import tomlkit
 import typer
+from bumpversion.exceptions import BumpVersionError
 
 from rhiza_tools.commands.bump import (
     BumpOptions,
@@ -561,7 +562,9 @@ def test_bump_configuration_load_failure(bump_project, monkeypatch):
     """Test bump command when configuration loading fails."""
 
     def mock_get_config(*args, **kwargs):
-        raise Exception("Configuration load error")  # noqa: TRY002, TRY003
+        from bumpversion.exceptions import ConfigurationError
+
+        raise ConfigurationError("Configuration load error")  # noqa: TRY003
 
     monkeypatch.setattr("rhiza_tools.commands.bump_engine.get_configuration", mock_get_config)
 
@@ -575,7 +578,7 @@ def test_bump_operation_failure(bump_project, monkeypatch):
     """Test bump command when the bump operation fails."""
 
     def mock_do_bump(*args, **kwargs):
-        raise Exception("Bump operation failed")  # noqa: TRY002, TRY003
+        raise BumpVersionError("Bump operation failed")  # noqa: TRY003
 
     monkeypatch.setattr("rhiza_tools.commands.bump_engine.do_bump", mock_do_bump)
 
@@ -902,9 +905,11 @@ class TestPreflightValidation:
         original_content = (bump_project / "pyproject.toml").read_text()
 
         def mock_do_bump(*args, **kwargs):
+            from bumpversion.exceptions import BumpVersionError
+
             # Fail on the preflight (dry_run=True) call
             if kwargs.get("dry_run", False):
-                raise Exception("Simulated preflight failure")  # noqa: TRY002, TRY003
+                raise BumpVersionError("Simulated preflight failure")  # noqa: TRY003
             # Should never reach the real call
             raise AssertionError("Real bump should not be called after preflight failure")  # noqa: TRY003
 
@@ -1446,7 +1451,7 @@ class TestExecuteBump:
         mock_config_path = MagicMock()
 
         with (
-            patch("rhiza_tools.commands.bump_engine.do_bump", side_effect=Exception("bump failed")),
+            patch("rhiza_tools.commands.bump_engine.do_bump", side_effect=BumpVersionError("bump failed")),
             pytest.raises(typer.Exit),
         ):
             _execute_bump("1.0.1", mock_config, mock_config_path, dry_run=False)
@@ -1459,7 +1464,7 @@ class TestExecuteBump:
         mock_config_path = MagicMock()
 
         with (
-            patch("rhiza_tools.commands.bump_engine.do_bump", side_effect=Exception("bump failed")),
+            patch("rhiza_tools.commands.bump_engine.do_bump", side_effect=BumpVersionError("bump failed")),
             pytest.raises(typer.Exit),
         ):
             _execute_bump("1.0.1", mock_config, mock_config_path, dry_run=True)

--- a/tests/test_bumpversion_contract.py
+++ b/tests/test_bumpversion_contract.py
@@ -21,6 +21,27 @@ def test_config_exposes_pre_commit_hooks_field():
     assert "pre_commit_hooks" in Config.model_fields
 
 
+def test_config_exposes_files_to_modify_attribute():
+    """``Config`` must expose ``files_to_modify`` (read by the engine's preview).
+
+    It is a computed property (not a declared model field), so the engine reads
+    it via ``hasattr``; if upstream renames it, the change preview breaks.
+    """
+    assert hasattr(Config, "files_to_modify")
+
+
+def test_bumpversion_error_base_is_importable():
+    """``BumpVersionError`` must remain the importable base the engine catches.
+
+    The engine narrows its ``do_bump``/config error handling to this type; if a
+    future release removes or relocates it, this fails here rather than letting a
+    real failure escape the adapter's clean ``typer.Exit`` boundary.
+    """
+    from bumpversion.exceptions import BumpVersionError
+
+    assert issubclass(BumpVersionError, Exception)
+
+
 def test_pre_commit_hooks_is_list_typed():
     """``pre_commit_hooks`` must be a list type whose default factory yields a list."""
     field = Config.model_fields["pre_commit_hooks"]

--- a/tests/test_e2e_bump_release.py
+++ b/tests/test_e2e_bump_release.py
@@ -461,7 +461,7 @@ class TestInteractiveReleaseWithBump:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command") as mock_bump,
+            patch("rhiza_tools.commands.release_versioning.bump_command") as mock_bump,
         ):
             release_command(bump_type="MINOR", push=True, dry_run=True)
 
@@ -519,7 +519,7 @@ class TestNonInteractiveReleaseBumpPush:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command") as mock_bump,
+            patch("rhiza_tools.commands.release_versioning.bump_command") as mock_bump,
         ):
             release_command(bump_type="MINOR", push=True, dry_run=True)
 
@@ -535,7 +535,7 @@ class TestNonInteractiveReleaseBumpPush:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command") as mock_bump,
+            patch("rhiza_tools.commands.release_versioning.bump_command") as mock_bump,
         ):
             release_command(bump_type="PATCH", push=True, dry_run=True)
 
@@ -551,7 +551,7 @@ class TestNonInteractiveReleaseBumpPush:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command") as mock_bump,
+            patch("rhiza_tools.commands.release_versioning.bump_command") as mock_bump,
         ):
             release_command(bump_type="MAJOR", push=True, dry_run=True)
 
@@ -707,7 +707,7 @@ class TestDryRunVersionCalculation:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
         ):
             # This should succeed - it should look for tag v0.2.0, not v0.1.0
             release_command(bump_type="MINOR", push=True, dry_run=True)
@@ -742,7 +742,7 @@ class TestDryRunVersionCalculation:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
         ):
             # Should succeed: tag v0.2.0 doesn't exist yet, but that's OK in dry-run
             release_command(bump_type="MINOR", push=True, dry_run=True)
@@ -766,7 +766,7 @@ class TestWithBumpFlag:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
             patch("questionary.select") as mock_select,
         ):
             mock_select.return_value.ask.return_value = "Minor (0.1.0 -> 0.2.0)"
@@ -784,7 +784,7 @@ class TestWithBumpFlag:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command") as mock_bump,
+            patch("rhiza_tools.commands.release_versioning.bump_command") as mock_bump,
             patch("questionary.select") as mock_select,
         ):
             mock_select.return_value.ask.return_value = "Minor (0.1.0 -> 0.2.0)"
@@ -802,7 +802,7 @@ class TestWithBumpFlag:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command") as mock_bump,
+            patch("rhiza_tools.commands.release_versioning.bump_command") as mock_bump,
         ):
             release_command(with_bump=True, non_interactive=True, push=True, dry_run=True)
 
@@ -836,7 +836,7 @@ class TestWithBumpFlag:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command") as mock_bump,
+            patch("rhiza_tools.commands.release_versioning.bump_command") as mock_bump,
         ):
             # --bump MAJOR should take priority, --with-bump should not trigger prompt
             release_command(bump_type="MAJOR", with_bump=True, push=True, dry_run=True)
@@ -1085,6 +1085,6 @@ class TestNonDefaultBranchRelease:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
         ):
             release_command(bump_type="MINOR", push=True, dry_run=True)

--- a/tests/test_module_size.py
+++ b/tests/test_module_size.py
@@ -1,15 +1,18 @@
 """Module-size gate keeping command modules small enough to navigate.
 
-Issue #207 split the oversized ``bump.py`` into focused modules. This gate
-prevents regression: every command module must stay at or below an 800-line
-ceiling, so future growth is split out rather than accreted into one file.
+Issue #207 split the oversized ``bump.py`` into focused modules, and #223 gave
+``release.py`` (-> ``release_versioning.py``) and ``rollback.py`` (->
+``rollback_git.py``) the same treatment, leaving the largest command module at
+~700 lines. This gate prevents regression: every command module must stay at or
+below a 750-line ceiling, so future growth is split out rather than accreted
+into one file.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-_MAX_LINES = 800
+_MAX_LINES = 750
 _COMMANDS_DIR = Path(__file__).resolve().parent.parent / "src" / "rhiza_tools" / "commands"
 
 

--- a/tests/test_release_command.py
+++ b/tests/test_release_command.py
@@ -658,7 +658,7 @@ def test_release_with_bump_flag(mock_pyproject, monkeypatch):
 
     with (
         patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_run_git_command),
-        patch("rhiza_tools.commands.release.bump_command", side_effect=mock_bump_command),
+        patch("rhiza_tools.commands.release_versioning.bump_command", side_effect=mock_bump_command),
     ):
         release_command(bump_type="PATCH", push=True, dry_run=True)
 
@@ -739,7 +739,7 @@ def test_release_non_interactive_with_bump(mock_pyproject, monkeypatch):
 
     with (
         patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-        patch("rhiza_tools.commands.release.bump_command", side_effect=mock_bump_command),
+        patch("rhiza_tools.commands.release_versioning.bump_command", side_effect=mock_bump_command),
     ):
         release_command(bump_type="MINOR", push=True, non_interactive=True)
 
@@ -857,7 +857,7 @@ def test_release_with_bump_push_checks_branch_before_pushing_commit(mock_pyproje
 
     with (
         patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-        patch("rhiza_tools.commands.release.bump_command", side_effect=mock_bump_command),
+        patch("rhiza_tools.commands.release_versioning.bump_command", side_effect=mock_bump_command),
     ):
         release_command(bump_type="PATCH", push=True, non_interactive=True)
 
@@ -885,7 +885,7 @@ def test_release_with_bump_dry_run_does_not_push_commit(mock_pyproject, monkeypa
 
     with (
         patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-        patch("rhiza_tools.commands.release.bump_command"),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
     ):
         release_command(bump_type="PATCH", push=True, dry_run=True)
 
@@ -983,7 +983,7 @@ def test_perform_version_bump_dry_run(mock_pyproject, monkeypatch):
     def mock_bump_command(options):
         bump_called["called"] = True
 
-    with patch("rhiza_tools.commands.release.bump_command", side_effect=mock_bump_command):
+    with patch("rhiza_tools.commands.release_versioning.bump_command", side_effect=mock_bump_command):
         new_version = _perform_version_bump("1.3.0", dry_run=True, language=Language.PYTHON)
 
     assert bump_called["called"]
@@ -1122,7 +1122,7 @@ class TestReleasePreflightValidation:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_run_git_command),
-            patch("rhiza_tools.commands.release.bump_command", side_effect=mock_bump_command),
+            patch("rhiza_tools.commands.release_versioning.bump_command", side_effect=mock_bump_command),
             pytest.raises(typer.Exit),
         ):
             release_command(bump_type="PATCH", push=True, non_interactive=True)
@@ -1159,7 +1159,7 @@ class TestReleasePreflightValidation:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_run_git_command),
-            patch("rhiza_tools.commands.release.bump_command", side_effect=mock_bump_command),
+            patch("rhiza_tools.commands.release_versioning.bump_command", side_effect=mock_bump_command),
             pytest.raises(typer.Exit),
         ):
             release_command(bump_type="PATCH", push=True, non_interactive=True)
@@ -1176,7 +1176,7 @@ class TestReleasePreflightValidation:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
         ):
             # Should complete without error in dry-run
             release_command(bump_type="PATCH", push=True, dry_run=True)
@@ -1201,7 +1201,7 @@ class TestReleasePreflightValidation:
 
         with (
             patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.bump_command", side_effect=mock_bump_command),
+            patch("rhiza_tools.commands.release_versioning.bump_command", side_effect=mock_bump_command),
         ):
             release_command(bump_type="PATCH", push=True, non_interactive=True)
 
@@ -1333,7 +1333,7 @@ def test_release_command_go_with_bump(mock_go_project, monkeypatch):
 
     with (
         patch("rhiza_tools.commands.release.run_git_command", side_effect=mock_run_git_command),
-        patch("rhiza_tools.commands.release.bump_command", side_effect=mock_bump_command),
+        patch("rhiza_tools.commands.release_versioning.bump_command", side_effect=mock_bump_command),
     ):
         release_command(bump_type="PATCH", push=True, dry_run=True, language=Language.GO)
 
@@ -1359,9 +1359,9 @@ class TestResolveInteractivePromptBumpExit:
 
         with (
             patch("questionary.confirm", return_value=mock_confirm),
-            patch("rhiza_tools.commands.release.get_current_version", return_value="1.0.0"),
+            patch("rhiza_tools.commands.release_versioning.get_current_version", return_value="1.0.0"),
             patch(
-                "rhiza_tools.commands.release.get_interactive_bump_type",
+                "rhiza_tools.commands.release_versioning.get_interactive_bump_type",
                 side_effect=typer.Exit(),
             ),
         ):
@@ -1379,9 +1379,9 @@ class TestResolveInteractivePromptBumpExit:
 
         with (
             patch("questionary.confirm", return_value=mock_confirm),
-            patch("rhiza_tools.commands.release.get_current_version", return_value="1.0.0"),
+            patch("rhiza_tools.commands.release_versioning.get_current_version", return_value="1.0.0"),
             patch(
-                "rhiza_tools.commands.release.get_interactive_bump_type",
+                "rhiza_tools.commands.release_versioning.get_interactive_bump_type",
                 side_effect=EOFError,
             ),
         ):
@@ -1475,7 +1475,7 @@ class TestHandleTagValidation:
 def test_resolve_explicit_bump_type_invalid_semver():
     """Test _resolve_explicit_bump_type raises Exit when current version is not valid semver."""
     with (
-        patch("rhiza_tools.commands.release.get_current_version", return_value="not-a-semver"),
+        patch("rhiza_tools.commands.release_versioning.get_current_version", return_value="not-a-semver"),
         pytest.raises(typer.Exit),
     ):
         _resolve_explicit_bump_type("MINOR", Language.PYTHON)
@@ -1484,7 +1484,7 @@ def test_resolve_explicit_bump_type_invalid_semver():
 def test_resolve_explicit_bump_type_invalid_bump_type():
     """Test _resolve_explicit_bump_type raises Exit when bump type is unrecognized."""
     with (
-        patch("rhiza_tools.commands.release.get_current_version", return_value="1.0.0"),
+        patch("rhiza_tools.commands.release_versioning.get_current_version", return_value="1.0.0"),
         pytest.raises(typer.Exit),
     ):
         _resolve_explicit_bump_type("INVALID", Language.PYTHON)
@@ -1519,8 +1519,8 @@ def test_resolve_interactive_prompt_bump_success():
 
     with (
         patch("questionary.confirm", return_value=mock_confirm),
-        patch("rhiza_tools.commands.release.get_current_version", return_value="1.0.0"),
-        patch("rhiza_tools.commands.release.get_interactive_bump_type", return_value="1.1.0"),
+        patch("rhiza_tools.commands.release_versioning.get_current_version", return_value="1.0.0"),
+        patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="1.1.0"),
     ):
         result = _resolve_interactive_prompt(Language.PYTHON)
 

--- a/tests/test_rollback_command.py
+++ b/tests/test_rollback_command.py
@@ -6,6 +6,7 @@ import pytest
 import typer
 
 import rhiza_tools.commands.rollback as rollback_mod
+import rhiza_tools.commands.rollback_git as rollback_git_mod
 from rhiza_tools.commands.rollback import (
     RollbackOptions,
     _confirm_rollback,
@@ -175,7 +176,7 @@ class TestGetTagCommit:
         mock_result.returncode = 0
         mock_result.stdout = "abc123def456\n"
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             commit = _get_tag_commit("v1.2.3")
             assert commit == "abc123def456"
 
@@ -185,7 +186,7 @@ class TestGetTagCommit:
         mock_result.returncode = 1
         mock_result.stdout = ""
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             commit = _get_tag_commit("v9.9.9")
             assert commit is None
 
@@ -204,7 +205,7 @@ class TestGetTagDetails:
         mock_result.returncode = 0
         mock_result.stdout = "abc123|2025-01-01 12:00:00|Bump version: 1.2.2 → 1.2.3"
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             details = _get_tag_details("v1.2.3")
             assert details["hash"] == "abc123"
             assert details["date"] == "2025-01-01 12:00:00"
@@ -216,7 +217,7 @@ class TestGetTagDetails:
         mock_result.returncode = 1
         mock_result.stdout = ""
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             details = _get_tag_details("v9.9.9")
             assert details == {}
 
@@ -243,7 +244,7 @@ class TestIsBumpCommit:
             mock_result.returncode = 0
             mock_result.stdout = msg
 
-            with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+            with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
                 assert _is_bump_commit("v1.2.3"), f"Should detect: {msg}"
 
     def test_rejects_non_bump_commit(self):
@@ -252,7 +253,7 @@ class TestIsBumpCommit:
         mock_result.returncode = 0
         mock_result.stdout = "Add new feature X"
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             assert not _is_bump_commit("v1.2.3")
 
     def test_returns_false_on_failure(self):
@@ -261,7 +262,7 @@ class TestIsBumpCommit:
         mock_result.returncode = 1
         mock_result.stdout = ""
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             assert not _is_bump_commit("v9.9.9")
 
 
@@ -279,7 +280,7 @@ class TestGetPreviousVersionFromTags:
         mock_result.returncode = 0
         mock_result.stdout = "v1.2.3\nv1.2.2\nv1.2.1\n"
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             prev = _get_previous_version_from_tags("v1.2.3")
             assert prev == "v1.2.2"
 
@@ -289,7 +290,7 @@ class TestGetPreviousVersionFromTags:
         mock_result.returncode = 0
         mock_result.stdout = "v0.1.0\n"
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             prev = _get_previous_version_from_tags("v0.1.0")
             assert prev is None
 
@@ -299,7 +300,7 @@ class TestGetPreviousVersionFromTags:
         mock_result.returncode = 0
         mock_result.stdout = "v1.2.3\nv1.2.2\n"
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             prev = _get_previous_version_from_tags("v9.9.9")
             assert prev is None
 
@@ -309,7 +310,7 @@ class TestGetPreviousVersionFromTags:
         mock_result.returncode = 1
         mock_result.stdout = ""
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             prev = _get_previous_version_from_tags("v1.2.3")
             assert prev is None
 
@@ -327,12 +328,12 @@ class TestDeleteLocalTag:
         mock_result = MagicMock()
         mock_result.returncode = 0
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             assert _delete_local_tag("v1.2.3", dry_run=False)
 
     def test_dry_run_does_not_delete(self):
         """Should not actually delete in dry-run mode."""
-        with patch.object(rollback_mod, "run_git_command") as mock_cmd:
+        with patch.object(rollback_git_mod, "run_git_command") as mock_cmd:
             assert _delete_local_tag("v1.2.3", dry_run=True)
             mock_cmd.assert_not_called()
 
@@ -342,7 +343,7 @@ class TestDeleteLocalTag:
         mock_result.returncode = 1
         mock_result.stderr = "error: tag 'v1.2.3' not found."
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             assert not _delete_local_tag("v1.2.3", dry_run=False)
 
 
@@ -359,12 +360,12 @@ class TestDeleteRemoteTag:
         mock_result = MagicMock()
         mock_result.returncode = 0
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             assert _delete_remote_tag("v1.2.3", dry_run=False)
 
     def test_dry_run_does_not_delete(self):
         """Should not actually delete in dry-run mode."""
-        with patch.object(rollback_mod, "run_git_command") as mock_cmd:
+        with patch.object(rollback_git_mod, "run_git_command") as mock_cmd:
             assert _delete_remote_tag("v1.2.3", dry_run=True)
             mock_cmd.assert_not_called()
 
@@ -374,7 +375,7 @@ class TestDeleteRemoteTag:
         mock_result.returncode = 1
         mock_result.stderr = "error: unable to delete 'v1.2.3'"
 
-        with patch.object(rollback_mod, "run_git_command", return_value=mock_result):
+        with patch.object(rollback_git_mod, "run_git_command", return_value=mock_result):
             assert not _delete_remote_tag("v1.2.3", dry_run=False)
 
 
@@ -396,7 +397,7 @@ class TestRevertBumpCommit:
                 return mock_revert
             return MagicMock(returncode=0, stdout="")
 
-        with patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git):
+        with patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git):
             assert _revert_bump_commit("abc123def456", dry_run=False)
 
     def test_dry_run_does_not_revert(self):
@@ -410,7 +411,7 @@ class TestRevertBumpCommit:
                 return mock_log
             return MagicMock(returncode=0, stdout="")
 
-        with patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git):
+        with patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git):
             assert _revert_bump_commit("abc123def456", dry_run=True)
 
     def test_handles_revert_failure(self):
@@ -424,7 +425,7 @@ class TestRevertBumpCommit:
                 return mock_revert
             return MagicMock(returncode=0, stdout="")
 
-        with patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git):
+        with patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git):
             assert not _revert_bump_commit("abc123def456", dry_run=False)
 
 
@@ -628,6 +629,7 @@ class TestRollbackCommand:
 
         with (
             patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git),
+            patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git),
             patch.object(rollback_mod, "check_tag_exists", return_value=(False, False)),
             pytest.raises(typer.Exit) as exc_info,
         ):
@@ -653,6 +655,7 @@ class TestRollbackCommand:
 
         with (
             patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git),
+            patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git),
             patch.object(rollback_mod, "check_tag_exists", return_value=(True, True)),
         ):
             rollback_command(RollbackOptions(tag="v1.2.3", dry_run=True, non_interactive=True))
@@ -678,6 +681,7 @@ class TestRollbackCommand:
 
         with (
             patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git),
+            patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git),
             patch.object(rollback_mod, "check_tag_exists", return_value=(True, True)),
         ):
             rollback_command(RollbackOptions(tag="v1.2.3", revert_bump=True, dry_run=True, non_interactive=True))
@@ -703,6 +707,7 @@ class TestRollbackCommand:
 
         with (
             patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git),
+            patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git),
             patch.object(rollback_mod, "check_tag_exists", return_value=(True, True)),
         ):
             rollback_command(RollbackOptions(tag="v1.2.3", non_interactive=True))
@@ -732,6 +737,7 @@ class TestRollbackCommand:
 
         with (
             patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git),
+            patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git),
             patch.object(rollback_mod, "check_tag_exists", return_value=(True, True)),
             pytest.raises(typer.Exit) as exc_info,
         ):
@@ -760,6 +766,7 @@ class TestRollbackCommand:
 
         with (
             patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git),
+            patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git),
             patch.object(rollback_mod, "check_tag_exists", return_value=(True, True)),
             pytest.raises(typer.Exit) as exc_info,
         ):
@@ -785,6 +792,7 @@ class TestRollbackCommand:
 
         with (
             patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git),
+            patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git),
             patch.object(rollback_mod, "check_tag_exists", return_value=(True, False)) as mock_check,
         ):
             rollback_command(RollbackOptions(tag="1.2.3", dry_run=True, non_interactive=True))
@@ -810,6 +818,7 @@ class TestRollbackCommand:
 
         with (
             patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git),
+            patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git),
             patch.object(rollback_mod, "check_tag_exists", return_value=(True, False)),
         ):
             rollback_command(RollbackOptions(tag="v1.2.3", non_interactive=True))
@@ -833,6 +842,7 @@ class TestRollbackCommand:
 
         with (
             patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git),
+            patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git),
             patch.object(rollback_mod, "check_tag_exists", return_value=(True, False)),
         ):
             rollback_command(RollbackOptions(non_interactive=True))
@@ -852,6 +862,7 @@ class TestRollbackCommand:
 
         with (
             patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git),
+            patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git),
             pytest.raises(typer.Exit) as exc_info,
         ):
             rollback_command(RollbackOptions(non_interactive=True))
@@ -880,6 +891,7 @@ class TestRollbackCommand:
 
         with (
             patch.object(rollback_mod, "run_git_command", side_effect=mock_run_git),
+            patch.object(rollback_git_mod, "run_git_command", side_effect=mock_run_git),
             patch.object(rollback_mod, "check_tag_exists", return_value=(True, True)),
         ):
             rollback_command(RollbackOptions(tag="v1.2.3", revert_bump=True, non_interactive=True))


### PR DESCRIPTION
Addresses the repo-owned half of the **#217** "10/10 across the board" effort. The other four issues (#219, #220, #221, #225) were closed separately as template-owned or already-satisfied by the Rhiza template (see their comments).

## What's here

### #218 — Type Safety
- Replace `BumpConfig = Any` in `bump_engine.py` with bump-my-version's concrete `Config` (which `do_bump` requires anyway), so every helper is fully checked under strict `ty`.

### #224 — Code Quality
- Narrow the four broad `except Exception` handlers to the domains upstream actually raises, verified empirically:
  - config load → `(BumpVersionError, ValueError, OSError)` (a bad TOML raises tomlkit's `ParseError`, a `ValueError`)
  - `do_bump` preflight/execute → `(BumpVersionError, OSError)`
  - file preview → `OSError`
- Tests updated to raise realistic exceptions; the bump-my-version contract test now also pins `files_to_modify` and `BumpVersionError`.

### #223 — Structure
- Extract bump-type resolution from `release.py` → `release_versioning.py` (750 → 606 lines).
- Extract git tag/commit plumbing from `rollback.py` → `rollback_git.py` (703 → 535 lines).
- Both re-exported, so the public import surface is unchanged; test patch targets moved to where dependencies now resolve.
- Module-size gate tightened 800 → 750 to lock in the smaller band.

### #222 — Documentation
- Populate the empty `docs/adr/` with 5 MADR-style ADRs (adapter + contract test, changelog-in-bump-commit, quality gates, structural meta-tests, module-split convention) + an index, wired into the mkdocs nav.

### #226 — Governance
- Add `docs/development/DECISIONS.md`: when an ADR is required, how to add one, and which files are repo-owned vs. template-synced.

## Verification
- `pytest`: **441 passed**, **100% coverage** held (`--cov-fail-under=100`)
- `ty check src`: clean (strict, `error-on-warning`)
- `ruff check` + `ruff format --check`: clean
- `interrogate`: 100% docstring coverage
- `.rhiza` structural + sync tests: 41 passed

Closes #218
Closes #222
Closes #223
Closes #224
Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)