### PR TITLE
fix(ci): pin scorecard/codeql actions to commit SHAs (fix imposter-commit error)

### DIFF
--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -57,7 +57,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -73,6 +73,6 @@ jobs:
           retention-days: 5
 
       - name: Upload results to code scanning
-        uses: github/codeql-action/upload-sarif@f52b05f4acaaa234e44466e66d29050e135ea9ef # v4.36.0
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

The Scorecard workflow on `main` (added in #242) fails when publishing results:

```
error: workflow verification failed: imposter commit:
99c09fe975337306107572b4fdf4db224cf8e2f2 does not belong to ossf/scorecard-action
```

#242 pinned `ossf/scorecard-action` and `github/codeql-action` to their **annotated tag-object** SHAs instead of the underlying **commit** SHAs. The OpenSSF Scorecard webapp verifies that the pinned ref is a commit belonging to the action's repo, so it rejected the upload with a 400.

## Fix

Dereferenced each tag to its commit SHA:

| Action | Was (tag object) | Now (commit) |
|---|---|---|
| `ossf/scorecard-action@v2.4.3` | `99c09fe` | `4eaacf0` |
| `github/codeql-action@v4.36.0` | `f52b05f` | `7211b7c` |

`actions/checkout@de0fac2` and `actions/upload-artifact@043fb46` were already valid commit SHAs and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)