### PR TITLE
quality: enable ERA/T10/PIE/PL/BLE ruff rules + narrow broad excepts (#233, #235)

### DIFF
--- a/.rhiza/utils/pip_audit_policy.py
+++ b/.rhiza/utils/pip_audit_policy.py
@@ -31,7 +31,7 @@ def main() -> int:
     """Run pip-audit and apply tiered vulnerability policy."""
     uvx = shutil.which("uvx") or "uvx"
     cmd = [uvx, "pip-audit", "--format", "json", *sys.argv[1:]]
-    proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603  # nosec B603
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)  # noqa: S603  # nosec B603
 
     if proc.returncode == 0:
         print(f"{_GREEN}[OK] pip-audit: no vulnerabilities found{_RESET}")

--- a/.rhiza/utils/suppression_audit.py
+++ b/.rhiza/utils/suppression_audit.py
@@ -206,7 +206,7 @@ def _active_pip_audit_ids(extra_args: list[str]) -> set[str]:
     """Return vulnerability IDs currently reported by pip-audit."""
     uvx = shutil.which("uvx") or "uvx"
     cmd = [uvx, "pip-audit", "--format", "json", *extra_args]
-    proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603  # nosec B603
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)  # noqa: S603  # nosec B603
 
     if proc.returncode not in {0, 1}:
         sys.stdout.write(proc.stdout)

--- a/ruff.toml
+++ b/ruff.toml
@@ -73,19 +73,30 @@ extend-select = [
     "PT",    # flake8-pytest-style - Check pytest best practices
     "RUF",   # Ruff-specific rules
     "S",     # flake8-bandit - Find security issues
-    #"ERA",   # eradicate - Find commented out code
-    #"T10",   # flake8-debugger - Check for debugger imports and calls
+    "BLE",   # flake8-blind-except - Flag blind `except Exception` handlers
+    "ERA",   # eradicate - Find commented out code
+    "T10",   # flake8-debugger - Check for debugger imports and calls
     "TRY",   # flake8-try-except-raise - Try/except/raise checks
     "ICN",   # flake8-import-conventions - Import convention enforcement
     "C901",  # mccabe - Flag overly complex functions (cyclomatic complexity)
-    #"PIE",   # flake8-pie - Miscellaneous rules
-    #"PL",    # Pylint rules
+    "PIE",   # flake8-pie - Miscellaneous rules
+    "PL",    # Pylint rules
 ]
 
 # Resolve incompatible pydocstyle rules: prefer D211 and D212 over D203 and D213
 ignore = [
     "D203",  # one-blank-line-before-class (conflicts with D211)
     "D213",  # multi-line-summary-second-line (conflicts with D212)
+    # The following Pylint rules conflict with deliberate, established patterns in
+    # this codebase. Each is disabled project-wide with its rationale rather than
+    # scattered per-line `noqa`s.
+    "PLC0414",  # `import x as x` is the explicit re-export convention used by the
+                # split command modules (bump/release/rollback re-export helpers).
+    "PLC0415",  # Local/lazy imports are intentional — CLI startup performance,
+                # avoiding import cycles, and per-test isolation.
+    "PLR0913",  # CLI command and orchestration functions legitimately accept many
+                # parameters (one per user-facing flag); structure is already
+                # guarded by the C901 complexity gate and the module-size gate.
 ]
 
 [lint.mccabe]
@@ -106,19 +117,20 @@ line-ending = "auto"
 
 # File-specific rule exceptions
 [lint.per-file-ignores]
-# Test files - allow assert statements and subprocess calls for testing
+# Test files (both project tests/ and template .rhiza/tests/) - allow patterns
+# that are normal in test code but undesirable in production source.
 "**/tests/**/*.py" = [
     "S101",     # Allow assert statements in tests
     "S603",     # Allow subprocess calls without shell=False check
     "S607",     # Allow starting processes with partial paths in tests
     "PLW1510",  # Allow subprocess without explicit check parameter
-]
-"tests/**/*.py" = [
-    "ERA001",   # Allow commented out code in project tests
-    "PLR2004",  # Allow magic values in project tests
-    "RUF002",   # Allow ambiguous unicode in project tests
-    "RUF012",   # Allow mutable class attributes in project tests
+    "ERA001",   # Allow commented out code in tests
+    "PLR2004",  # Allow magic values in tests
+    "RUF002",   # Allow ambiguous unicode in tests
+    "RUF012",   # Allow mutable class attributes in tests
     "C901",     # Complexity gate targets production code; tests use elaborate mock setups
+    "PLR0911",  # Test doubles/dispatchers legitimately have many return branches
+    "PLR1714",  # Readability of explicit comparison chains is fine in tests
 ]
 # Marimo notebooks - allow flexible coding patterns for interactive exploration
 "**/notebooks/*.py" = [

--- a/src/rhiza_tools/commands/bump_io.py
+++ b/src/rhiza_tools/commands/bump_io.py
@@ -131,14 +131,14 @@ def get_current_version(language: Language) -> str:
             # Convert PEP 440 format back to semver format for compatibility
             # e.g., 0.1.1a1 -> 0.1.1-alpha.1
             return _denormalize_pep440_to_semver(str(data["project"]["version"]))
-        except Exception as e:
+        except (OSError, tomllib.TOMLDecodeError, KeyError) as e:
             console.error(f"Failed to read version from pyproject.toml: {e}")
             raise typer.Exit(code=1) from None
     elif language == Language.GO:
         try:
             with open("VERSION") as f:
                 version = f.read().strip()
-        except Exception as e:
+        except OSError as e:
             console.error(f"Failed to read version from VERSION file: {e}")
             raise typer.Exit(code=1) from None
 
@@ -222,9 +222,8 @@ def get_interactive_bump_type(current_version_str: str) -> str:
     if not choice:
         raise typer.Exit(code=0)
 
-    # Extract the new version string from the choice
-    # Format is "Label (Current -> New)"
-    # We want "New"
+    # Extract the new version string from the choice. Each menu label has the
+    # form Label (Current -> New); the portion after the arrow is what we keep.
     # Check if the choice contains the expected format (skip separators)
     if "-> " not in choice:
         console.error("Invalid choice selection")
@@ -294,7 +293,7 @@ def _log_bump_success(current_version_str: str, config: Any, language: Language)
                     content = file_path.read_text()
                     if updated_version in content:
                         console.info(f"  • {file_path}")
-                except Exception:  # nosec B110 - safe to ignore file read errors  # noqa: S110
+                except Exception:  # nosec B110 - safe to ignore file read errors  # noqa: S110, BLE001
                     pass
 
     console.info("\nDon't forget to run 'uv lock' to update the lockfile if needed.")

--- a/src/rhiza_tools/commands/generate_badge.py
+++ b/src/rhiza_tools/commands/generate_badge.py
@@ -11,6 +11,19 @@ from pathlib import Path
 
 from rhiza_tools import console
 
+# Coverage percentage bounds and the (minimum coverage, shields.io color) ladder,
+# ordered from highest to lowest. Higher coverage gets "greener" colors.
+MIN_COVERAGE = 0
+MAX_COVERAGE = 100
+_COLOR_THRESHOLDS: list[tuple[int, str]] = [
+    (90, "brightgreen"),
+    (80, "green"),
+    (70, "yellowgreen"),
+    (60, "yellow"),
+    (50, "orange"),
+]
+_DEFAULT_COLOR = "red"
+
 
 def get_badge_color(coverage: int) -> str:
     """Determine badge color based on coverage percentage.
@@ -32,18 +45,10 @@ def get_badge_color(coverage: int) -> str:
         >>> print(color)
         red
     """
-    if coverage >= 90:
-        return "brightgreen"
-    elif coverage >= 80:
-        return "green"
-    elif coverage >= 70:
-        return "yellowgreen"
-    elif coverage >= 60:
-        return "yellow"
-    elif coverage >= 50:
-        return "orange"
-    else:
-        return "red"
+    for threshold, color in _COLOR_THRESHOLDS:
+        if coverage >= threshold:
+            return color
+    return _DEFAULT_COLOR
 
 
 def generate_coverage_badge_command(
@@ -102,7 +107,7 @@ def generate_coverage_badge_command(
     # Round to nearest integer
     coverage = round(percent)
 
-    if not 0 <= coverage <= 100:
+    if not MIN_COVERAGE <= coverage <= MAX_COVERAGE:
         console.error(f"Coverage percentage {coverage} is out of valid range 0-100")
         sys.exit(1)
 

--- a/src/rhiza_tools/commands/release_git.py
+++ b/src/rhiza_tools/commands/release_git.py
@@ -17,6 +17,11 @@ import typer
 from rhiza_tools import console
 from rhiza_tools.commands._shared import run_git_command
 
+# Number of fields in the `%H|%ci|%s` git-show format (commit hash, date, subject).
+_TAG_DETAIL_FIELDS = 3
+# Cap on how many commits are listed when previewing a release.
+_MAX_COMMITS_SHOWN = 10
+
 
 def get_current_branch() -> str:
     """Get the current git branch name for the release flow.
@@ -89,25 +94,24 @@ def check_branch_status(current_branch: str) -> None:
             console.error("Pull the latest changes before releasing:")
             console.error(f"  git pull origin {current_branch}")
             raise typer.Exit(code=1)
+        # Either local is ahead of remote OR branches have diverged
+        # Check if remote == base to distinguish between the two cases
+        elif remote == base:
+            # Local is ahead of remote (need to push)
+            console.warning(f"Your branch is ahead of '{upstream}'.")
+            console.info("Unpushed commits:")
+            result = run_git_command(["git", "log", "--oneline", "--graph", "--decorate", f"{upstream}..HEAD"])
+            console.info(result.stdout)
+            console.warning("Please push changes to remote before releasing.")
+            raise typer.Exit(code=1)
         else:
-            # Either local is ahead of remote OR branches have diverged
-            # Check if remote == base to distinguish between the two cases
-            if remote == base:
-                # Local is ahead of remote (need to push)
-                console.warning(f"Your branch is ahead of '{upstream}'.")
-                console.info("Unpushed commits:")
-                result = run_git_command(["git", "log", "--oneline", "--graph", "--decorate", f"{upstream}..HEAD"])
-                console.info(result.stdout)
-                console.warning("Please push changes to remote before releasing.")
-                raise typer.Exit(code=1)
-            else:
-                # Branches have diverged (need to merge or rebase)
-                console.error(f"Your branch has diverged from '{upstream}'.")
-                console.error("To reconcile, choose one of:")
-                console.error(f"  Rebase: git pull --rebase origin {current_branch}")
-                console.error(f"  Merge:  git merge origin/{current_branch}")
-                console.error("Then resolve any conflicts and retry.")
-                raise typer.Exit(code=1)
+            # Branches have diverged (need to merge or rebase)
+            console.error(f"Your branch has diverged from '{upstream}'.")
+            console.error("To reconcile, choose one of:")
+            console.error(f"  Rebase: git pull --rebase origin {current_branch}")
+            console.error(f"  Merge:  git merge origin/{current_branch}")
+            console.error("Then resolve any conflicts and retry.")
+            raise typer.Exit(code=1)
 
 
 def get_default_branch() -> str:
@@ -253,7 +257,7 @@ def _validate_tag_state(tag: str, current_version: str) -> None:
     result = run_git_command(["git", "show", "-s", "--format=%H|%ci|%s", tag], check=False)
     if result.returncode == 0 and result.stdout.strip():
         parts = result.stdout.strip().split("|")
-        if len(parts) == 3:
+        if len(parts) == _TAG_DETAIL_FIELDS:
             commit_hash, commit_date, commit_msg = parts
             console.info(f"  Commit: {commit_hash[:8]}")
             console.info(f"  Date: {commit_date}")
@@ -284,10 +288,10 @@ def _show_commits_since_last_tag(tag: str) -> None:
     if log_result.returncode == 0 and log_result.stdout.strip():
         commits = log_result.stdout.strip().split("\n")
         console.info(f"\nCommits included in this release (since {last_tag}):")
-        for commit in commits[:10]:  # Show first 10
+        for commit in commits[:_MAX_COMMITS_SHOWN]:
             console.info(f"  • {commit}")
-        if len(commits) > 10:
-            console.info(f"  ... and {len(commits) - 10} more")
+        if len(commits) > _MAX_COMMITS_SHOWN:
+            console.info(f"  ... and {len(commits) - _MAX_COMMITS_SHOWN} more")
 
 
 def _confirm_and_push_tag(

--- a/src/rhiza_tools/commands/rollback.py
+++ b/src/rhiza_tools/commands/rollback.py
@@ -274,9 +274,8 @@ def _execute_rollback(
             if not dry_run:
                 console.warning("Bump revert failed. Tags were still deleted.")
                 console.warning("You may need to manually revert the bump commit.")
-        else:
-            if not _push_revert(dry_run, non_interactive):
-                success = False
+        elif not _push_revert(dry_run, non_interactive):
+            success = False
 
     return success
 

--- a/src/rhiza_tools/commands/rollback_git.py
+++ b/src/rhiza_tools/commands/rollback_git.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 from rhiza_tools import console
 from rhiza_tools.commands._shared import run_git_command
 
+# Number of fields in the `%H|%ci|%s` git-show format (commit hash, date, subject).
+_TAG_DETAIL_FIELDS = 3
+
 
 def _get_tag_commit(tag: str) -> str | None:
     """Get the commit hash that a tag points to.
@@ -43,7 +46,7 @@ def _get_tag_details(tag: str) -> dict[str, str]:
     )
     if result.returncode == 0 and result.stdout.strip():
         parts = result.stdout.strip().split("|")
-        if len(parts) == 3:
+        if len(parts) == _TAG_DETAIL_FIELDS:
             details["hash"] = parts[0]
             details["date"] = parts[1]
             details["message"] = parts[2]

--- a/src/rhiza_tools/commands/version_matrix.py
+++ b/src/rhiza_tools/commands/version_matrix.py
@@ -135,8 +135,8 @@ def satisfies(version: str, specifier: str) -> bool:
     version_tuple = parse_version(version)
 
     # Split by comma for multiple constraints
-    for spec in specifier.split(","):
-        spec = spec.strip()
+    for raw_spec in specifier.split(","):
+        spec = raw_spec.strip()
         # Match operator and version part
         match = re.match(r"(>=|<=|>|<|==|!=)\s*([\d.]+)", spec)
         if not match:

--- a/src/rhiza_tools/console.py
+++ b/src/rhiza_tools/console.py
@@ -36,7 +36,7 @@ def configure(*, verbose: bool = False) -> None:
     Args:
         verbose: If True, enable loguru debug output on stderr.
     """
-    global _verbose
+    global _verbose  # noqa: PLW0603 - module-level verbosity flag set once from the CLI callback
     _verbose = verbose
 
     # Remove all default loguru handlers (the default one logs to stderr at DEBUG)


### PR DESCRIPTION
## Summary

Closes #233 (Linting → 10) and #235 (Code Quality → 10).

### #233 — enable the commented-out ruff rule sets
Enabled `ERA`, `T10`, `PIE`, `PL` (and `BLE` for #235) in `ruff.toml`. No commented-out entries remain in `extend-select`. Rules that conflict with deliberate, established patterns are disabled **project-wide with a one-line rationale** instead:

| Rule | Why ignored |
|---|---|
| `PLC0414` | `import x as x` is the explicit re-export convention of the split command modules |
| `PLC0415` | local/lazy imports are intentional (CLI startup perf, cycle avoidance, test isolation) |
| `PLR0913` | CLI functions take one parameter per user flag; structure already guarded by C901 + module-size gates |

### #235 — replace broad `except Exception`
- `bump_io.get_current_version`: narrowed to `(OSError, tomllib.TOMLDecodeError, KeyError)` (pyproject path) and `OSError` (VERSION path).
- The remaining best-effort file-read catch keeps its deliberate broad form, now justified with `# noqa: BLE001` alongside the existing `nosec`/`noqa: S110`.

### Genuine findings fixed (not ignored)
- `PLR2004`: named constants for badge color thresholds + git-format field counts.
- `PLW2901`: renamed a shadowed loop variable in `version_matrix.satisfies`.
- `PLW0603`: justified the single module-level verbosity-flag write.
- `ERA001`: reworded a prose comment ruff misread as commented-out code.
- `PLR5501`: collapsed `else: if` → `elif`.
- `PLW1510`: added explicit `check=False` to two `.rhiza/utils` subprocess calls.

Test `per-file-ignores` extended so `.rhiza/tests` and test-only rules (PLR0911/PLR1714) are covered.

## Testing
- `ruff check .` + `ruff format --check .` clean repo-wide
- All 444 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)