### PR TITLE
type-safety: remove Any escape hatches in config/bump (#232)

### DIFF
--- a/src/rhiza_tools/commands/bump.py
+++ b/src/rhiza_tools/commands/bump.py
@@ -19,8 +19,6 @@ Example:
         bump_command(None)
 """
 
-from typing import Any
-
 import semver
 import typer
 
@@ -33,6 +31,7 @@ from rhiza_tools.commands._shared import (
 # Re-export the bump-my-version adapter helpers for the same reason. Names called
 # directly inside this module (bump_command) need no alias; pure re-exports use one.
 from rhiza_tools.commands.bump_engine import (
+    BumpConfig,
     _build_changelog_hooks,
     _build_configuration,
     _execute_bump,
@@ -176,7 +175,7 @@ def _resolve_language(options: BumpOptions) -> Language:
 def _finalize_bump(
     options: BumpOptions,
     current_version_str: str,
-    config: Any,
+    config: BumpConfig,
     language: Language,
     commit: bool,
     push: bool,

--- a/src/rhiza_tools/commands/bump_engine.py
+++ b/src/rhiza_tools/commands/bump_engine.py
@@ -10,7 +10,6 @@ interface this adapter relies on.
 """
 
 from pathlib import Path
-from typing import Any
 
 import typer
 from bumpversion.bump import do_bump
@@ -52,7 +51,7 @@ def _build_configuration(
     """
     if config_path is None:
         config_path = Path(CONFIG_FILENAME)
-    overrides: dict[str, Any] = {"current_version": current_version_str}
+    overrides: dict[str, str | bool] = {"current_version": current_version_str}
     if allow_dirty:
         overrides["allow_dirty"] = True
     if commit:

--- a/src/rhiza_tools/commands/bump_io.py
+++ b/src/rhiza_tools/commands/bump_io.py
@@ -16,7 +16,7 @@ import tomllib
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 import questionary as qs
 import semver
@@ -28,7 +28,7 @@ from rhiza_tools.commands._shared import (
     COOL_STYLE,
     NON_INTERACTIVE_ERRORS,
 )
-from rhiza_tools.commands.bump_engine import _get_files_to_modify
+from rhiza_tools.commands.bump_engine import BumpConfig, _get_files_to_modify
 from rhiza_tools.commands.bump_versioning import (
     _denormalize_pep440_to_semver,
     get_next_prerelease,
@@ -262,7 +262,7 @@ def _validate_project_exists(language: Language) -> None:
         raise typer.Exit(code=1)
 
 
-def _log_bump_success(current_version_str: str, config: Any, language: Language) -> None:
+def _log_bump_success(current_version_str: str, config: BumpConfig, language: Language) -> None:
     """Log successful version bump and post-bump instructions.
 
     Args:

--- a/src/rhiza_tools/config.py
+++ b/src/rhiza_tools/config.py
@@ -63,7 +63,7 @@ class RhizaConfig:
                 default path defined in CONFIG_FILENAME.
         """
         self.config_path = config_path or Path(CONFIG_FILENAME)
-        self._data: dict[str, Any] = {}
+        self._data: tomlkit.TOMLDocument = tomlkit.TOMLDocument()
         self.load()
 
     def load(self) -> None:
@@ -92,6 +92,10 @@ class RhizaConfig:
             raise
 
     @property
+    # Returns the raw ``[tool.bumpversion]`` TOML sub-table. Its keys and value
+    # types are user-defined and open-ended (strings, bools, lists, nested
+    # tables), so ``dict[str, Any]`` is the honest type for this passthrough —
+    # the strongly-typed bump path uses bump-my-version's own ``Config`` model.
     def bumpversion(self) -> dict[str, Any]:
         """Get bumpversion configuration.
 
@@ -107,6 +111,8 @@ class RhizaConfig:
         result: dict[str, Any] = self._data.get("tool", {}).get("bumpversion", {})
         return result
 
+    # Generic accessor over arbitrary top-level TOML keys; the value type is
+    # only known to the caller, so ``Any`` is intentional here (TOML passthrough).
     def get(self, key: str, default: Any = None) -> Any:
         """Get configuration value.
 


### PR DESCRIPTION
## Summary

Closes #232 (Type Safety → 10).

Removes the `Any` escape hatches from the version-bump / config-parsing path:

| Location | Before | After |
|---|---|---|
| `bump.py` `_finalize_bump` | `config: Any` | `config: BumpConfig` |
| `bump_io.py` `_log_bump_success` | `config: Any` | `config: BumpConfig` |
| `bump_engine.py` `_build_configuration` | `overrides: dict[str, Any]` | `dict[str, str \| bool]` |
| `config.py` `RhizaConfig._data` | `dict[str, Any]` | `tomlkit.TOMLDocument` |

`BumpConfig` is bump-my-version's concrete `Config` model — the same type `_get_files_to_modify` already required, so these functions were only ever handed a `Config`.

The remaining `Any` in `src/` is confined to `RhizaConfig.bumpversion` / `RhizaConfig.get` — generic accessors over open-ended TOML where `Any` is the honest type. Each now carries a one-line justification, exactly as the issue allows ("Keep dict[str, Any] only where genuinely dynamic (TOML passthrough) and justify with a comment").

## Testing
- `ty check src/` (strict, `error-on-warning = true`) — **All checks passed**
- `ruff check` / `ruff format --check` clean
- All 444 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)