### PR TITLE
security: SHA-pin third-party actions in rhiza_fuzzing.yml (#234)

### DIFF
--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -26,19 +26,19 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Build fuzzers
-        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: python
           sanitizer: address
 
       - name: Run PR fuzzing
         if: github.event_name == 'pull_request'
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: python
           mode: code-change
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run scheduled fuzzing
         if: github.event_name != 'pull_request'
-        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
           language: python
           mode: batch


### PR DESCRIPTION
## Summary

Closes #234 (Security → 10: SHA-pin repo-owned GitHub Actions).

Pins the third-party actions in `rhiza_fuzzing.yml` — the last repo-owned workflow still using floating tags — to full commit SHAs:

| Action | Pin |
|---|---|
| `actions/checkout` | `de0fac2` # v6.0.2 |
| `google/clusterfuzzlite/actions/build_fuzzers` | `884713a` # v1 |
| `google/clusterfuzzlite/actions/run_fuzzers` (×2) | `884713a` # v1 |

(`v1` is an annotated tag → commit `884713a`; that's what `@v1` already resolved to, so behaviour is unchanged.)

### Scope — what is and isn't repo-owned
`.rhiza/template.lock` is the authoritative list of **sync-managed** files. The two workflows the repo fully owns and inlines — `rhiza_scorecard.yml` (pinned in #242/#243) and `rhiza_fuzzing.yml` (this PR) — are **not** in that list, so these pins are durable.

The remaining inlined workflows that still use floating tags (`rhiza_release.yml`, etc.) **are** sync-managed from `jebel-quant/rhiza`. Pinning them here would be reverted on the next `make sync`, so they must be pinned upstream in the template, not in this repo. `dependabot.yml` already has the `github-actions` ecosystem enabled to keep these SHAs current.

## Testing
- `actionlint` + workflow-validation pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)