### PR TITLE
ci: codify (and enforce) main branch protection as a ruleset (#238)

### DIFF
--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -1,0 +1,63 @@
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash", "merge", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "ci / Pre-commit hooks" },
+          { "context": "ci / Security scanning" },
+          { "context": "ci / validation" },
+          { "context": "ci / generate-matrix" },
+          { "context": "ci / Check dependencies with deptry" },
+          { "context": "ci / License compliance scan" },
+          { "context": "ci / docs-coverage" },
+          { "context": "ci / Lowest-direct dependency compatibility" },
+          { "context": "ci / Type checking (Python 3.11)" },
+          { "context": "ci / Type checking (Python 3.12)" },
+          { "context": "ci / Type checking (Python 3.13)" },
+          { "context": "ci / Type checking (Python 3.14)" },
+          { "context": "ci / test (3.11, ubuntu-latest)" },
+          { "context": "ci / test (3.11, macos-latest)" },
+          { "context": "ci / test (3.11, windows-latest)" },
+          { "context": "ci / test (3.12, ubuntu-latest)" },
+          { "context": "ci / test (3.12, macos-latest)" },
+          { "context": "ci / test (3.12, windows-latest)" },
+          { "context": "ci / test (3.13, ubuntu-latest)" },
+          { "context": "ci / test (3.13, macos-latest)" },
+          { "context": "ci / test (3.13, windows-latest)" },
+          { "context": "ci / test (3.14, ubuntu-latest)" },
+          { "context": "ci / test (3.14, macos-latest)" },
+          { "context": "ci / test (3.14, windows-latest)" },
+          { "context": "codeql / Analyze (python)" },
+          { "context": "codeql / Analyze (actions)" }
+        ]
+      }
+    }
+  ]
+}

--- a/docs/development/branch-protection.md
+++ b/docs/development/branch-protection.md
@@ -1,0 +1,56 @@
+# Branch protection (as code)
+
+The protection rules for the default branch (`main`) are codified in
+[`.github/rulesets/main-branch-protection.json`](https://github.com/Jebel-Quant/rhiza-tools/blob/main/.github/rulesets/main-branch-protection.json)
+as a GitHub **repository ruleset**, so they are reviewable and version-controlled
+rather than living only in the repository settings UI.
+
+## What the ruleset enforces
+
+On `main`:
+
+- **Pull request required** — no direct pushes; changes land through a PR with
+  **at least one approving review**, and stale approvals are dismissed when new
+  commits are pushed.
+- **Required status checks** (branch must be up to date before merge):
+  the full CI gate — pre-commit, security scanning, validation, deptry,
+  license-compliance, docs-coverage, lowest-direct-dependency compatibility,
+  `ty` type checking on 3.11–3.14, the `test` matrix across
+  {3.11, 3.12, 3.13, 3.14} × {ubuntu, macOS, windows}, and the CodeQL
+  `python` / `actions` analyses.
+- **Linear history** — merge commits that would create non-linear history are
+  rejected (squash/rebase/merge are all permitted as merge methods).
+- **No force pushes** and **no branch deletion**.
+
+Heavy or external checks that do not run deterministically on every PR
+(ClusterFuzzLite, CodeFactor, the Marimo notebook matrix) are intentionally
+**not** required, so they never block an otherwise-green PR.
+
+## Applying / updating the ruleset
+
+The JSON is in the REST API shape, so it can be applied directly. Create it once:
+
+```bash
+gh api --method POST repos/Jebel-Quant/rhiza-tools/rulesets \
+  --input .github/rulesets/main-branch-protection.json
+```
+
+To update an existing ruleset, find its id and `PUT` the same file:
+
+```bash
+RULESET_ID=$(gh api repos/Jebel-Quant/rhiza-tools/rulesets \
+  --jq '.[] | select(.name=="main-branch-protection") | .id')
+gh api --method PUT repos/Jebel-Quant/rhiza-tools/rulesets/"$RULESET_ID" \
+  --input .github/rulesets/main-branch-protection.json
+```
+
+The committed JSON is the source of truth: change it in a PR, then re-`PUT` it.
+
+## Notes for a solo maintainer
+
+The required approving review means GitHub will not let you merge your **own** PR
+without a second account approving it (you cannot approve your own PR). If you
+need to bypass this temporarily you can, as a repository admin, either add a
+bypass actor to the ruleset or set its `enforcement` to `evaluate` in
+**Settings → Rules**. Managing the ruleset itself is never blocked by the
+ruleset.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,3 +29,4 @@ nav:
     - 0005 command module split: adr/0005-command-module-split.md
   - Contributing:
     - Recording decisions: development/DECISIONS.md
+    - Branch protection: development/branch-protection.md


### PR DESCRIPTION
## Summary

Closes #238 (CI/CD → 10).

### 1. Branch protection as code ✅ (this PR)
`main` had **no** protection (no ruleset, no classic branch protection). This adds [`.github/rulesets/main-branch-protection.json`](../blob/main/.github/rulesets/main-branch-protection.json) — a GitHub repository ruleset in REST-API shape — plus [`docs/development/branch-protection.md`](../blob/main/docs/development/branch-protection.md). The ruleset has been **applied to `main`** (`enforcement: active`, id 17638638). It enforces:
- PR + 1 approving review (stale approvals dismissed on push)
- the full CI gate as required status checks (pre-commit, security, validation, deptry, license, docs-coverage, lowest-dep, `ty` 3.11–3.14, the 12-way `test` matrix, CodeQL python/actions), branch up to date
- linear history, no force-push, no deletion

Heavy/non-deterministic checks (ClusterFuzzLite, CodeFactor, Marimo) are intentionally not required. The JSON is the source of truth — edit in a PR and re-`PUT` (commands in the doc).

### 2. Release provenance ✅ (already satisfied)
`rhiza_release.yml` already runs `actions/attest-build-provenance@v4` (SLSA provenance for the wheel/sdist) and `actions/attest@v4.1.0` (SBOM). No change needed.

### 3. Coverage artifact ⬆️ (upstream)
CI currently uploads only `LICENSES.md`. Adding a coverage-report artifact upload belongs in `rhiza_ci.yml`, which is **sync-managed** from `jebel-quant/rhiza` (per `.rhiza/template.lock`); a local edit would be reverted on the next sync, so it should be made upstream in the template.

> Note for a solo maintainer: the 1-review rule means you can't self-approve your own PRs. As repo admin you can add a bypass actor or set the ruleset to `evaluate` in Settings → Rules if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)