### PR TITLE
feat(release): always bump on release; remove --with-bump

### DIFF
--- a/src/rhiza_tools/cli.py
+++ b/src/rhiza_tools/cli.py
@@ -220,11 +220,8 @@ def generate_coverage_badge(
 
 @app.command()
 def release(
-    bump: str | None = typer.Option(None, "--bump", help="Bump type (MAJOR, MINOR, PATCH) before release."),
-    with_bump: bool = typer.Option(
-        False,
-        "--with-bump",
-        help="Interactively select bump type before release (works with --dry-run).",
+    bump: str | None = typer.Option(
+        None, "--bump", help="Bump type (MAJOR, MINOR, PATCH). Selected interactively when omitted."
     ),
     push: bool = typer.Option(False, "--push", help="Push changes to remote (default: prompt in interactive mode)."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Print what would happen without doing it."),
@@ -240,27 +237,28 @@ def release(
     config: Path | None = CONFIG_OPTION,
     verbose: bool = VERBOSE_OPTION,
 ) -> None:
-    """Push a release tag to remote to trigger the release workflow.
+    """Bump the version and push a release tag to remote to trigger the release workflow.
 
-    This command validates the repository state and pushes the git tag for the
-    current version to the remote repository, which triggers the automated release
-    workflow. Supports Python projects (pyproject.toml) and Go projects
-    (go.mod + VERSION file). The project language is auto-detected when not
-    explicitly specified.
+    A release always bumps the version before tagging: the bump type is taken
+    from ``--bump`` when given, selected interactively otherwise, or defaults to
+    patch in non-interactive mode. The command then validates the repository
+    state and pushes the git tag, which triggers the automated release workflow.
+    Supports Python projects (pyproject.toml) and Go projects (go.mod + VERSION
+    file). The project language is auto-detected when not explicitly specified.
 
     Args:
-        bump: Bump type (MAJOR, MINOR, PATCH) to apply before release.
-        with_bump: If True, interactively select bump type before release.
+        bump: Bump type (MAJOR, MINOR, PATCH) to apply. Selected interactively when omitted.
         push: If True, push changes without prompting (implies non-interactive for push).
         dry_run: If True, show what would happen without actually pushing the tag.
-        non_interactive: If True, skip all confirmation prompts (useful for CI/CD).
+        non_interactive: If True, skip all confirmation prompts and default the bump to
+            patch when no --bump type is given (useful for CI/CD).
         language: Programming language (python or go). Auto-detected if not specified.
         allow_older: If True, allow releasing a version not newer than the latest remote release.
-        config: Path to the .cfg.toml bumpversion config file. Passed through to bump when --with-bump is used.
+        config: Path to the .cfg.toml bumpversion config file. Passed through to the bump.
         verbose: If True, enable verbose debug output.
 
     Example:
-        Push a release tag (with prompts)::
+        Bump (interactive) and release::
 
             $ rhiza-tools release
 
@@ -268,21 +266,17 @@ def release(
 
             $ rhiza-tools release --dry-run
 
-        Non-interactive mode (for CI/CD)::
+        Non-interactive patch release (for CI/CD)::
 
             $ rhiza-tools release --non-interactive
 
-        Bump version and release::
+        Explicit bump and release::
 
             $ rhiza-tools release --bump MINOR --push
 
-        Bump version and release with custom config::
+        Explicit bump and release with custom config::
 
             $ rhiza-tools release --bump MINOR --push --config /path/to/.cfg.toml
-
-        Interactive bump with dry-run preview::
-
-            $ rhiza-tools release --with-bump --push --dry-run
 
         Release a Go project::
 
@@ -300,7 +294,7 @@ def release(
             console.error("Supported languages: python, go")
             raise typer.Exit(code=1) from None
 
-    release_command(bump, push, dry_run, non_interactive, with_bump, lang_enum, config, allow_older)
+    release_command(bump, push, dry_run, non_interactive, lang_enum, config, allow_older)
 
 
 @app.command()

--- a/src/rhiza_tools/commands/release.py
+++ b/src/rhiza_tools/commands/release.py
@@ -73,17 +73,11 @@ from rhiza_tools.commands.release_git import (
 # Bump-type resolution lives in release_versioning; re-exported here so the
 # public import surface (and existing tests) keep using ``release.<helper>``.
 from rhiza_tools.commands.release_versioning import (
-    _get_bump_type_interactively,
     _perform_version_bump,
+    _resolve_required_bump,
 )
 from rhiza_tools.commands.release_versioning import (
     _resolve_explicit_bump_type as _resolve_explicit_bump_type,
-)
-from rhiza_tools.commands.release_versioning import (
-    _resolve_interactive_prompt as _resolve_interactive_prompt,
-)
-from rhiza_tools.commands.release_versioning import (
-    _resolve_with_bump_flag as _resolve_with_bump_flag,
 )
 
 
@@ -209,27 +203,30 @@ def release_command(
     push: bool = False,
     dry_run: bool = False,
     non_interactive: bool = False,
-    with_bump: bool = False,
     language: Language | None = None,
     config: Path | None = None,
     allow_older: bool = False,
 ) -> None:
-    """Push a release tag to remote.
+    """Bump the version and push a release tag to remote.
 
-    This command performs the following steps:
+    A release always bumps the version before tagging — there is no tag-only
+    path. This command performs the following steps:
     1. Detects the project language (Python or Go) unless explicitly specified
-    2. Optionally bumps the version if bump_type is provided or with_bump is True
+    2. Resolves the bump (explicit ``bump_type``, interactive prompt, or a patch
+       default in non-interactive mode) and bumps the version
     3. Reads the current version from pyproject.toml (Python) or VERSION file (Go)
     4. Validates the git repository state (clean working tree, up-to-date with remote)
     5. Checks that a tag exists for the current version (created by bump-my-version)
     6. Pushes the tag to remote, triggering the release workflow
 
     Args:
-        bump_type: Optional bump type (MAJOR, MINOR, PATCH) to apply before release.
+        bump_type: Optional bump type (MAJOR, MINOR, PATCH) to apply. When omitted,
+            the bump type is selected interactively (or defaults to patch in
+            non-interactive mode).
         push: If True, push changes without prompting.
         dry_run: If True, show what would be done without making any changes.
-        non_interactive: If True, skip all confirmation prompts.
-        with_bump: If True, enable interactive bump selection (works with dry-run).
+        non_interactive: If True, skip all confirmation prompts and default the
+            bump to patch when no ``bump_type`` is given.
         language: Programming language (python or go). Auto-detected if not specified.
         config: Optional path to the .cfg.toml bumpversion config file.
         allow_older: If True, permit releasing a version that is not strictly
@@ -241,7 +238,7 @@ def release_command(
             tag doesn't exist, or any git operations fail.
 
     Example:
-        Push a release tag::
+        Bump (interactive) and release::
 
             release_command()
 
@@ -249,17 +246,13 @@ def release_command(
 
             release_command(dry_run=True)
 
-        Non-interactive mode::
+        Non-interactive patch release::
 
             release_command(non_interactive=True)
 
-        Bump and release::
+        Explicit bump and release::
 
             release_command(bump_type="MINOR", push=True)
-
-        Interactive bump with dry-run::
-
-            release_command(with_bump=True, push=True, dry_run=True)
 
         Release a Go project::
 
@@ -279,10 +272,9 @@ def release_command(
     current_branch = get_current_branch()
     console.info(f"Current branch: {typer.style(current_branch, fg=typer.colors.CYAN, bold=True)}")
 
-    # Interactive mode: ask if user wants to bump version
-    should_bump, new_version = _get_bump_type_interactively(
-        non_interactive, bump_type, dry_run, with_bump, language=language
-    )
+    # A release always bumps: resolve the bump target (explicit, interactive, or
+    # patch default in non-interactive mode).
+    _, new_version = _resolve_required_bump(non_interactive, bump_type, language=language)
 
     # ── Preflight validation: check everything BEFORE making any changes ──
     default_branch = get_default_branch()
@@ -291,11 +283,10 @@ def release_command(
     # Ensure the version we are about to release is strictly newer than the
     # latest version already published on the remote (issue #1126). Runs in all
     # modes (including dry-run) and before any mutation.
-    prospective_version = new_version if (should_bump and new_version) else get_current_version(language)
-    _check_release_version_monotonic(prospective_version, allow_older)
+    _check_release_version_monotonic(new_version, allow_older)
 
-    # If bumping, pre-validate that the new tag won't conflict with remote
-    if should_bump and new_version and not dry_run:
+    # Pre-validate that the new tag won't conflict with remote
+    if not dry_run:
         new_tag = f"v{new_version}"
         _, exists_remotely = check_tag_exists(new_tag)
         if exists_remotely:
@@ -309,10 +300,8 @@ def release_command(
 
     # ── Execute: all preflight checks passed, safe to make changes ──
 
-    # Perform bump if requested (bump_command runs its own internal preflight)
-    bumped_new_version: str | None = None
-    if should_bump and new_version:
-        bumped_new_version = _perform_version_bump(new_version, dry_run, language, config)
+    # Perform the bump (bump_command runs its own internal preflight)
+    bumped_new_version = _perform_version_bump(new_version, dry_run, language, config)
 
     # Get current version and tag
     current_version, tag = _get_release_version(dry_run, bumped_new_version, language)

--- a/src/rhiza_tools/commands/release_versioning.py
+++ b/src/rhiza_tools/commands/release_versioning.py
@@ -1,8 +1,8 @@
 """Bump-type resolution for the release command.
 
-The release command can optionally bump the version before tagging. Working out
-*which* version to bump to — from an explicit ``--bump`` type, the ``--with-bump``
-flag, or an interactive prompt — is a self-contained concern with no git
+A release always bumps the version before tagging. Working out *which* version
+to bump to — from an explicit ``--bump`` type, an interactive prompt, or a patch
+default in non-interactive mode — is a self-contained concern with no git
 plumbing, so it lives here rather than in ``release.py``. ``release.py``
 re-exports these helpers, so the public import surface is unchanged.
 """
@@ -11,10 +11,8 @@ from pathlib import Path
 
 import semver
 import typer
-from loguru import logger
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import NON_INTERACTIVE_ERRORS
 from rhiza_tools.commands.bump import (
     BumpOptions,
     Language,
@@ -25,43 +23,39 @@ from rhiza_tools.commands.bump import (
     get_interactive_bump_type,
 )
 
-# Combined tuple for catching both typer.Exit and non-interactive environment errors.
-_EXIT_OR_NON_INTERACTIVE: tuple[type[BaseException], ...] = (typer.Exit, *NON_INTERACTIVE_ERRORS)
 
+def _resolve_required_bump(non_interactive: bool, bump_type: str | None, *, language: Language) -> tuple[bool, str]:
+    """Resolve the version bump to apply before releasing.
 
-def _get_bump_type_interactively(
-    non_interactive: bool, bump_type: str | None, dry_run: bool, with_bump: bool = False, *, language: Language
-) -> tuple[bool, str | None]:
-    """Get bump version interactively or from parameters.
-
-    Uses the same interactive selection as the bump command to ensure consistent
-    behavior between ``rhiza-tools bump`` and ``rhiza-tools release --with-bump``.
+    A release always bumps, so this never returns "no bump". The bump target is
+    resolved, in order of precedence, from: an explicit ``bump_type``; a patch
+    default when running non-interactively without one; or an interactive prompt
+    for the bump type. Cancelling the interactive prompt raises ``typer.Exit``
+    (via :func:`get_interactive_bump_type`), aborting the release.
 
     Args:
-        non_interactive: If True, skip interactive prompts.
-        bump_type: Explicit bump type provided (e.g., "MAJOR", "MINOR", "PATCH").
-        dry_run: If True, the bump will be simulated (handled by caller).
-        with_bump: If True, enable interactive bump selection directly.
+        non_interactive: If True, skip prompts and default to a patch bump.
+        bump_type: Explicit bump type (e.g., "MAJOR", "MINOR", "PATCH"), if given.
         language: The programming language for version reading.
 
     Returns:
-        Tuple of (should_bump, new_version_string). The version string is the
-        explicit new version (not a bump type keyword).
+        Tuple of ``(True, new_version_string)`` — the explicit new version to
+        bump to (not a bump-type keyword).
     """
     if bump_type:
         return _resolve_explicit_bump_type(bump_type, language)
 
-    if with_bump:
-        return _resolve_with_bump_flag(non_interactive, language)
+    current_version_str = _resolve_bump_baseline(get_current_version(language))
 
-    if not non_interactive:
-        return _resolve_interactive_prompt(language)
+    if non_interactive:
+        console.warning("No --bump type given in non-interactive mode, defaulting to patch")
+        current_semver = semver.Version.parse(current_version_str)
+        return True, str(current_semver.bump_patch())
 
-    # Non-interactive without --with-bump or --bump: no bump
-    return False, None
+    return True, get_interactive_bump_type(current_version_str)
 
 
-def _resolve_explicit_bump_type(bump_type: str, language: Language) -> tuple[bool, str | None]:
+def _resolve_explicit_bump_type(bump_type: str, language: Language) -> tuple[bool, str]:
     """Resolve version from an explicitly provided bump type.
 
     Args:
@@ -84,63 +78,6 @@ def _resolve_explicit_bump_type(bump_type: str, language: Language) -> tuple[boo
     if not new_version:
         console.error(f"Invalid bump type: {bump_type}")
         raise typer.Exit(code=1)
-    return True, new_version
-
-
-def _resolve_with_bump_flag(non_interactive: bool, language: Language) -> tuple[bool, str | None]:
-    """Resolve version when --with-bump flag is set.
-
-    In non-interactive mode defaults to patch; otherwise prompts interactively.
-
-    Args:
-        non_interactive: If True, default to a patch bump.
-        language: The programming language for version reading.
-
-    Returns:
-        Tuple of (should_bump, new_version_string).
-    """
-    if non_interactive:
-        console.warning("--with-bump in non-interactive mode without --bump type, defaulting to patch")
-        current_version_str = _resolve_bump_baseline(get_current_version(language))
-        current_semver = semver.Version.parse(current_version_str)
-        return True, str(current_semver.bump_patch())
-
-    current_version_str = _resolve_bump_baseline(get_current_version(language))
-    try:
-        new_version = get_interactive_bump_type(current_version_str)
-    except _EXIT_OR_NON_INTERACTIVE:
-        return False, None
-    return True, new_version
-
-
-def _resolve_interactive_prompt(language: Language) -> tuple[bool, str | None]:
-    """Prompt the user interactively whether to bump before releasing.
-
-    Args:
-        language: The programming language for version reading.
-
-    Returns:
-        Tuple of (should_bump, new_version_string).
-    """
-    import questionary as qs
-
-    try:
-        should_bump = qs.confirm(
-            "Would you like to bump the version before releasing?",
-            default=False,
-        ).ask()
-    except NON_INTERACTIVE_ERRORS:
-        logger.debug("Running in non-interactive environment")
-        return False, None
-
-    if not should_bump:
-        return False, None
-
-    current_version_str = _resolve_bump_baseline(get_current_version(language))
-    try:
-        new_version = get_interactive_bump_type(current_version_str)
-    except _EXIT_OR_NON_INTERACTIVE:
-        return False, None
     return True, new_version
 
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -62,29 +62,29 @@ def test_release_command(monkeypatch):
 
     result = runner.invoke(app, ["release", "--dry-run"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
-    mock_release_command.assert_called_once_with(None, False, True, False, False, None, None, False)
+    # release_command(bump, push, dry_run, non_interactive, language, config, allow_older)
+    mock_release_command.assert_called_once_with(None, False, True, False, None, None, False)
 
     mock_release_command.reset_mock()
 
     result = runner.invoke(app, ["release"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
-    mock_release_command.assert_called_once_with(None, False, False, False, False, None, None, False)
+    # release_command(bump, push, dry_run, non_interactive, language, config, allow_older)
+    mock_release_command.assert_called_once_with(None, False, False, False, None, None, False)
 
     mock_release_command.reset_mock()
 
     result = runner.invoke(app, ["release", "--non-interactive"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
-    mock_release_command.assert_called_once_with(None, False, False, True, False, None, None, False)
+    # release_command(bump, push, dry_run, non_interactive, language, config, allow_older)
+    mock_release_command.assert_called_once_with(None, False, False, True, None, None, False)
 
     mock_release_command.reset_mock()
 
-    result = runner.invoke(app, ["release", "--with-bump", "--push", "--dry-run"])
+    result = runner.invoke(app, ["release", "--bump", "MINOR", "--push", "--dry-run"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
-    mock_release_command.assert_called_once_with(None, True, True, False, True, None, None, False)
+    # release_command(bump, push, dry_run, non_interactive, language, config, allow_older)
+    mock_release_command.assert_called_once_with("MINOR", True, True, False, None, None, False)
 
     mock_release_command.reset_mock()
 
@@ -92,8 +92,8 @@ def test_release_command(monkeypatch):
 
     result = runner.invoke(app, ["release", "--language", "go", "--dry-run"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
-    mock_release_command.assert_called_once_with(None, False, True, False, False, Language.GO, None, False)
+    # release_command(bump, push, dry_run, non_interactive, language, config, allow_older)
+    mock_release_command.assert_called_once_with(None, False, True, False, Language.GO, None, False)
 
     mock_release_command.reset_mock()
 
@@ -108,10 +108,8 @@ def test_release_command(monkeypatch):
 
     result = runner.invoke(app, ["release", "--config", "/custom/.cfg.toml", "--dry-run"])
     assert result.exit_code == 0
-    # release_command(bump, push, dry_run, non_interactive, with_bump, language, config, allow_older)
-    mock_release_command.assert_called_once_with(
-        None, False, True, False, False, None, Path("/custom/.cfg.toml"), False
-    )
+    # release_command(bump, push, dry_run, non_interactive, language, config, allow_older)
+    mock_release_command.assert_called_once_with(None, False, True, False, None, Path("/custom/.cfg.toml"), False)
 
 
 def test_update_readme(monkeypatch):

--- a/tests/test_e2e_bump_release.py
+++ b/tests/test_e2e_bump_release.py
@@ -2,7 +2,7 @@
 
 These tests exercise the full command workflows as described in the TESTING_GUIDE.md,
 covering interactive and non-interactive modes, dry-run, push, branch operations,
-and the --with-bump release flag.
+and the always-bump release behavior.
 """
 
 import shutil
@@ -19,7 +19,7 @@ from rhiza_tools.commands.bump import (
     get_current_version,
 )
 from rhiza_tools.commands.release import (
-    _get_bump_type_interactively,
+    _resolve_required_bump,
     release_command,
 )
 
@@ -422,6 +422,8 @@ class TestInteractiveRelease:
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
             patch("rhiza_tools.commands.release.typer.confirm", return_value=True),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="0.1.0"),
         ):
             release_command(dry_run=True)
 
@@ -437,6 +439,8 @@ class TestInteractiveRelease:
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
             patch("typer.confirm", return_value=False),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="0.1.0"),
             pytest.raises(typer.Exit) as exc_info,
         ):
             release_command()
@@ -563,22 +567,26 @@ class TestNonInteractiveReleaseBumpPush:
 # ──────────────────────────────────────────────
 
 
-class TestReleaseWithoutBump:
-    """Test 11: Release without bump - just push existing tag."""
+class TestReleasePushFlow:
+    """Test 11: Release push flow (always bumps before pushing the tag)."""
 
-    def test_release_push_existing_tag_dry_run(self, e2e_project):
-        """Push existing tag in dry-run mode."""
+    def test_release_push_dry_run(self, e2e_project):
+        """Push flow in dry-run mode."""
         subprocess.run([GIT, "tag", "v0.1.0"], check=True, capture_output=True)  # nosec B603
 
         mock_git = _make_mock_git_for_release(tag_exists_locally=True)
 
-        with patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git):
+        with (
+            patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="0.1.0"),
+        ):
             release_command(push=True, dry_run=True)
 
         assert get_current_version(Language.PYTHON) == "0.1.0"
 
     def test_release_push_non_interactive(self, e2e_project):
-        """Non-interactive push of existing tag."""
+        """Non-interactive push (defaults to a patch bump)."""
         subprocess.run([GIT, "tag", "v0.1.0"], check=True, capture_output=True)  # nosec B603
 
         mock_git = _make_mock_git_for_release(tag_exists_locally=True)
@@ -591,6 +599,7 @@ class TestReleaseWithoutBump:
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
             patch("rhiza_tools.commands.release_git.push_tag", side_effect=mock_push_tag),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
         ):
             release_command(push=True, non_interactive=True)
 
@@ -614,6 +623,8 @@ class TestReleaseCommitListing:
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
             patch("rhiza_tools.commands.release.typer.confirm", return_value=True),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="0.1.0"),
         ):
             # Should complete without errors
             release_command(dry_run=True)
@@ -659,6 +670,8 @@ class TestReleaseMissingTag:
 
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="0.1.0"),
             pytest.raises(typer.Exit),
         ):
             release_command()
@@ -681,6 +694,8 @@ class TestReleaseExistingRemoteTag:
 
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="0.1.0"),
             pytest.raises(typer.Exit),
         ):
             release_command()
@@ -728,6 +743,8 @@ class TestDryRunVersionCalculation:
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
             patch("rhiza_tools.commands.release.typer.confirm", return_value=True),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="0.1.0"),
         ):
             # Should NOT fail even with dirty working tree in dry-run
             release_command(dry_run=True)
@@ -749,15 +766,15 @@ class TestDryRunVersionCalculation:
 
 
 # ──────────────────────────────────────────────
-# --with-bump Feature Tests
+# Always-bump Release Tests (release always bumps the version)
 # ──────────────────────────────────────────────
 
 
-class TestWithBumpFlag:
-    """Tests for the --with-bump interactive release flag."""
+class TestAlwaysBump:
+    """Tests for the always-bump release behavior."""
 
-    def test_with_bump_prompts_for_type(self, e2e_project):
-        """--with-bump should prompt user for bump type (same as bump command)."""
+    def test_interactive_prompts_for_type(self, e2e_project):
+        """An interactive release should prompt the user for the bump type."""
         mock_git = _make_mock_git_for_release(
             tag_exists_locally=False,
             tag_exists_remotely=False,
@@ -770,12 +787,12 @@ class TestWithBumpFlag:
             patch("questionary.select") as mock_select,
         ):
             mock_select.return_value.ask.return_value = "Minor (0.1.0 -> 0.2.0)"
-            release_command(with_bump=True, push=True, dry_run=True)
+            release_command(push=True, dry_run=True)
 
         mock_select.assert_called_once()
 
-    def test_with_bump_dry_run_full_flow(self, e2e_project):
-        """--with-bump --push --dry-run: full interactive flow."""
+    def test_interactive_dry_run_full_flow(self, e2e_project):
+        """Interactive --push --dry-run: full bump flow."""
         mock_git = _make_mock_git_for_release(
             tag_exists_locally=False,
             tag_exists_remotely=False,
@@ -788,12 +805,12 @@ class TestWithBumpFlag:
             patch("questionary.select") as mock_select,
         ):
             mock_select.return_value.ask.return_value = "Minor (0.1.0 -> 0.2.0)"
-            release_command(with_bump=True, push=True, dry_run=True)
+            release_command(push=True, dry_run=True)
 
         mock_bump.assert_called_once()
 
-    def test_with_bump_non_interactive_defaults_to_patch(self, e2e_project):
-        """--with-bump in non-interactive mode without --bump should default to PATCH."""
+    def test_non_interactive_defaults_to_patch(self, e2e_project):
+        """Non-interactive release without --bump should default to PATCH."""
         mock_git = _make_mock_git_for_release(
             tag_exists_locally=False,
             tag_exists_remotely=False,
@@ -804,7 +821,7 @@ class TestWithBumpFlag:
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
             patch("rhiza_tools.commands.release_versioning.bump_command") as mock_bump,
         ):
-            release_command(with_bump=True, non_interactive=True, push=True, dry_run=True)
+            release_command(non_interactive=True, push=True, dry_run=True)
 
         mock_bump.assert_called_once()
         # Should have been called with BumpOptions containing the explicit version string
@@ -813,21 +830,20 @@ class TestWithBumpFlag:
         assert isinstance(options, BumpOptions)
         assert options.version == "0.1.1"
 
-    def test_with_bump_user_cancels_selection(self, e2e_project):
-        """--with-bump: user cancels bump type selection."""
+    def test_interactive_cancel_aborts_release(self, e2e_project):
+        """Cancelling the interactive bump-type selection aborts the release."""
         mock_git = _make_mock_git_for_release(tag_exists_locally=True)
 
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.typer.confirm", return_value=True),
             patch("questionary.select") as mock_select,
         ):
             mock_select.return_value.ask.return_value = None
-            # Should proceed without bump
-            release_command(with_bump=True, dry_run=True)
+            with pytest.raises(typer.Exit):
+                release_command(dry_run=True)
 
-    def test_with_bump_explicit_type_takes_priority(self, e2e_project):
-        """--bump MAJOR takes priority over --with-bump."""
+    def test_explicit_type_skips_prompt(self, e2e_project):
+        """An explicit --bump type should be used without prompting."""
         mock_git = _make_mock_git_for_release(
             tag_exists_locally=False,
             tag_exists_remotely=False,
@@ -837,10 +853,11 @@ class TestWithBumpFlag:
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
             patch("rhiza_tools.commands.release_versioning.bump_command") as mock_bump,
+            patch("questionary.select") as mock_select,
         ):
-            # --bump MAJOR should take priority, --with-bump should not trigger prompt
-            release_command(bump_type="MAJOR", with_bump=True, push=True, dry_run=True)
+            release_command(bump_type="MAJOR", push=True, dry_run=True)
 
+        mock_select.assert_not_called()
         mock_bump.assert_called_once()
         # Should have been called with BumpOptions containing the explicit version string
         call_args = mock_bump.call_args[0]
@@ -848,58 +865,49 @@ class TestWithBumpFlag:
         assert isinstance(options, BumpOptions)
         assert options.version == "1.0.0"
 
-    def test_with_bump_eoferror_handled(self, e2e_project):
-        """--with-bump should handle EOFError gracefully (non-tty)."""
+    def test_interactive_eoferror_aborts_release(self, e2e_project):
+        """A non-tty (EOFError) during interactive selection aborts the release."""
         mock_git = _make_mock_git_for_release(tag_exists_locally=True)
 
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands.release.typer.confirm", return_value=True),
             patch("questionary.select") as mock_select,
         ):
             mock_select.return_value.ask.side_effect = EOFError
-            # Should not crash, just skip bump
-            release_command(with_bump=True, dry_run=True)
+            with pytest.raises(typer.Exit):
+                release_command(dry_run=True)
 
 
 # ──────────────────────────────────────────────
-# _get_bump_type_interactively Tests
+# _resolve_required_bump Tests
 # ──────────────────────────────────────────────
 
 
-class TestGetBumpTypeInteractively:
-    """Tests for _get_bump_type_interactively with with_bump parameter."""
+class TestResolveRequiredBump:
+    """Tests for _resolve_required_bump."""
 
-    def test_explicit_bump_type_takes_priority(self, e2e_project):
-        """Explicit bump_type should be converted to version string."""
-        should_bump, new_version = _get_bump_type_interactively(
-            non_interactive=False, bump_type="MINOR", dry_run=False, with_bump=False, language=Language.PYTHON
+    def test_explicit_bump_type(self, e2e_project):
+        """Explicit bump_type should be converted to a version string."""
+        should_bump, new_version = _resolve_required_bump(
+            non_interactive=False, bump_type="MINOR", language=Language.PYTHON
         )
         assert should_bump is True
         assert new_version == "0.2.0"
 
-    def test_with_bump_non_interactive_defaults_patch(self, e2e_project):
-        """with_bump + non_interactive should default to patch version."""
-        should_bump, new_version = _get_bump_type_interactively(
-            non_interactive=True, bump_type=None, dry_run=True, with_bump=True, language=Language.PYTHON
+    def test_non_interactive_defaults_patch(self, e2e_project):
+        """non_interactive without a bump type should default to patch version."""
+        should_bump, new_version = _resolve_required_bump(
+            non_interactive=True, bump_type=None, language=Language.PYTHON
         )
         assert should_bump is True
         assert new_version == "0.1.1"
 
-    def test_dry_run_without_with_bump_skips_prompts(self):
-        """dry_run without with_bump should not prompt."""
-        should_bump, bump_type = _get_bump_type_interactively(
-            non_interactive=False, bump_type=None, dry_run=True, with_bump=False, language=Language.PYTHON
-        )
-        assert should_bump is False
-        assert bump_type is None
-
-    def test_with_bump_prompts_interactively(self, e2e_project):
-        """with_bump should use bump's interactive selection."""
+    def test_interactive_prompts(self, e2e_project):
+        """Interactive mode should use the interactive bump-type selection."""
         with patch("questionary.select") as mock_select:
             mock_select.return_value.ask.return_value = "Minor (0.1.0 -> 0.2.0)"
-            should_bump, new_version = _get_bump_type_interactively(
-                non_interactive=False, bump_type=None, dry_run=True, with_bump=True, language=Language.PYTHON
+            should_bump, new_version = _resolve_required_bump(
+                non_interactive=False, bump_type=None, language=Language.PYTHON
             )
         assert should_bump is True
         assert new_version == "0.2.0"
@@ -913,8 +921,8 @@ class TestGetBumpTypeInteractively:
 class TestCLIIntegration:
     """Tests for CLI command invocation via typer runner."""
 
-    def test_release_with_bump_cli_flag(self, monkeypatch):
-        """Test --with-bump flag is passed correctly via CLI."""
+    def test_release_push_dry_run_cli_flags(self, monkeypatch):
+        """Test --push --dry-run flags are passed correctly via CLI."""
         from typer.testing import CliRunner
 
         from rhiza_tools.cli import app
@@ -923,12 +931,13 @@ class TestCLIIntegration:
         mock_release = MagicMock()
         monkeypatch.setattr("rhiza_tools.cli.release_command", mock_release)
 
-        result = runner.invoke(app, ["release", "--with-bump", "--push", "--dry-run"])
+        result = runner.invoke(app, ["release", "--push", "--dry-run"])
         assert result.exit_code == 0
-        mock_release.assert_called_once_with(None, True, True, False, True, None, None, False)
+        # release_command(bump, push, dry_run, non_interactive, language, config, allow_older)
+        mock_release.assert_called_once_with(None, True, True, False, None, None, False)
 
-    def test_release_bump_and_with_bump_cli(self, monkeypatch):
-        """Test --bump MINOR --with-bump together via CLI."""
+    def test_release_explicit_bump_cli(self, monkeypatch):
+        """Test --bump MINOR --push via CLI."""
         from typer.testing import CliRunner
 
         from rhiza_tools.cli import app
@@ -937,9 +946,10 @@ class TestCLIIntegration:
         mock_release = MagicMock()
         monkeypatch.setattr("rhiza_tools.cli.release_command", mock_release)
 
-        result = runner.invoke(app, ["release", "--bump", "MINOR", "--with-bump", "--push"])
+        result = runner.invoke(app, ["release", "--bump", "MINOR", "--push"])
         assert result.exit_code == 0
-        mock_release.assert_called_once_with("MINOR", True, False, False, True, None, None, False)
+        # release_command(bump, push, dry_run, non_interactive, language, config, allow_older)
+        mock_release.assert_called_once_with("MINOR", True, False, False, None, None, False)
 
     def test_bump_cli_all_flags(self, monkeypatch):
         """Test bump CLI with all flags."""
@@ -995,6 +1005,8 @@ class TestSequentialBumpRelease:
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
             patch("rhiza_tools.commands.release.typer.confirm", return_value=True),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="0.1.1"),
         ):
             release_command(dry_run=True)
 
@@ -1070,6 +1082,8 @@ class TestNonDefaultBranchRelease:
         with (
             patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_git),
             patch("rhiza_tools.commands.release.typer.confirm", return_value=True),
+            patch("rhiza_tools.commands.release_versioning.bump_command"),
+            patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="0.1.0"),
         ):
             release_command(dry_run=True)
 

--- a/tests/test_release_command.py
+++ b/tests/test_release_command.py
@@ -9,7 +9,7 @@ import typer
 from rhiza_tools.commands.bump import BumpOptions, Language, get_current_version
 from rhiza_tools.commands.release import (
     _resolve_explicit_bump_type,
-    _resolve_interactive_prompt,
+    _resolve_required_bump,
     check_branch_status,
     check_clean_working_tree,
     check_tag_exists,
@@ -295,7 +295,8 @@ def test_release_command_dry_run(mock_pyproject, monkeypatch):
     with (
         patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command),
         patch("rhiza_tools.commands.release.typer.confirm", return_value=True),
-        patch("questionary.confirm", return_value=MagicMock(ask=MagicMock(return_value=False))),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+        patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="1.2.4"),
     ):
         release_command(dry_run=True)  # Should complete without errors
 
@@ -325,7 +326,8 @@ def test_release_command_tag_missing(mock_pyproject, monkeypatch):
 
     with (
         patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command),
-        patch("questionary.confirm", return_value=MagicMock(ask=MagicMock(return_value=False))),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+        patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="1.2.3"),
         pytest.raises(typer.Exit),
     ):
         release_command()
@@ -354,7 +356,8 @@ def test_release_command_tag_exists_remotely(mock_pyproject, monkeypatch):
 
     with (
         patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command),
-        patch("questionary.confirm", return_value=MagicMock(ask=MagicMock(return_value=False))),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+        patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="1.2.3"),
         pytest.raises(typer.Exit),
     ):
         release_command()
@@ -467,7 +470,10 @@ def test_release_command_non_default_branch_non_interactive(mock_pyproject, monk
 
         return result
 
-    with patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command):
+    with (
+        patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+    ):
         # Should not raise in non-interactive mode
         release_command(dry_run=True, non_interactive=True)
 
@@ -502,7 +508,10 @@ def test_release_command_with_commit_count(mock_pyproject, monkeypatch):
 
         return result
 
-    with patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command):
+    with (
+        patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+    ):
         release_command(dry_run=True, non_interactive=True)
 
 
@@ -537,7 +546,8 @@ def test_release_command_user_declines_push(mock_pyproject, monkeypatch):
     with (
         patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command),
         patch("typer.confirm", return_value=False),
-        patch("questionary.confirm", return_value=MagicMock(ask=MagicMock(return_value=False))),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+        patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="1.2.3"),
         pytest.raises(typer.Exit) as exc_info,
     ):
         release_command(dry_run=False, non_interactive=False)
@@ -574,7 +584,10 @@ def test_release_command_success_non_dry_run(mock_pyproject, monkeypatch):
 
         return result
 
-    with patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command):
+    with (
+        patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+    ):
         # Should complete successfully in non-interactive mode
         release_command(dry_run=False, non_interactive=True)
 
@@ -606,7 +619,8 @@ def test_release_command_user_declines_non_default_branch(mock_pyproject, monkey
     with (
         patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command),
         patch("typer.confirm", return_value=False),
-        patch("questionary.confirm", return_value=MagicMock(ask=MagicMock(return_value=False))),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+        patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="1.2.3"),
         pytest.raises(typer.Exit) as exc_info,
     ):
         release_command(dry_run=False, non_interactive=False)
@@ -705,7 +719,8 @@ def test_release_with_push_flag(mock_pyproject, monkeypatch):
     with (
         patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command),
         patch("rhiza_tools.commands.release_git.push_tag", side_effect=mock_push_tag),
-        patch("questionary.confirm", return_value=MagicMock(ask=MagicMock(return_value=False))),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+        patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="1.2.3"),
     ):
         release_command(push=True)
 
@@ -960,18 +975,36 @@ def test_validate_tag_state_git_show_fails(mock_pyproject, monkeypatch):
         # Should complete without showing tag details
 
 
-def test_get_bump_type_interactively_eoferror(monkeypatch):
-    """Test _get_bump_type_interactively handles EOFError."""
-    from rhiza_tools.commands.release import _get_bump_type_interactively
+def test_resolve_required_bump_non_interactive_defaults_to_patch(mock_pyproject, monkeypatch):
+    """Test _resolve_required_bump defaults to a patch bump in non-interactive mode."""
+    should_bump, new_version = _resolve_required_bump(True, None, language=Language.PYTHON)
 
-    # Mock questionary to raise EOFError
-    with patch("questionary.confirm") as mock_confirm:
-        mock_confirm.return_value.ask.side_effect = EOFError
+    assert should_bump is True
+    assert new_version == "1.2.4"
 
-        should_bump, bump_type = _get_bump_type_interactively(False, None, False, language=Language.PYTHON)
 
-        assert should_bump is False
-        assert bump_type is None
+def test_resolve_required_bump_interactive_uses_get_interactive_bump_type(mock_pyproject, monkeypatch):
+    """Test _resolve_required_bump uses get_interactive_bump_type in interactive mode."""
+    with patch(
+        "rhiza_tools.commands.release_versioning.get_interactive_bump_type",
+        return_value="2.0.0",
+    ):
+        should_bump, new_version = _resolve_required_bump(False, None, language=Language.PYTHON)
+
+    assert should_bump is True
+    assert new_version == "2.0.0"
+
+
+def test_resolve_required_bump_interactive_cancel_aborts(mock_pyproject, monkeypatch):
+    """Test _resolve_required_bump aborts when the interactive prompt is cancelled."""
+    with (
+        patch(
+            "rhiza_tools.commands.release_versioning.get_interactive_bump_type",
+            side_effect=typer.Exit(),
+        ),
+        pytest.raises(typer.Exit),
+    ):
+        _resolve_required_bump(False, None, language=Language.PYTHON)
 
 
 def test_perform_version_bump_dry_run(mock_pyproject, monkeypatch):
@@ -1250,7 +1283,10 @@ def test_release_command_go_project_dry_run(mock_go_project, monkeypatch):
 
         return result
 
-    with patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command):
+    with (
+        patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+    ):
         # Auto-detect should find Go project
         release_command(dry_run=True, non_interactive=True)
 
@@ -1283,7 +1319,10 @@ def test_release_command_go_project_explicit_language(mock_go_project, monkeypat
 
         return result
 
-    with patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command):
+    with (
+        patch("rhiza_tools.commands.release_git.run_git_command", side_effect=mock_run_git_command),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+    ):
         release_command(dry_run=True, non_interactive=True, language=Language.GO)
 
 
@@ -1344,50 +1383,6 @@ def test_release_command_go_with_bump(mock_go_project, monkeypatch):
 # ---------------------------------------------------------------------------
 # Branch/edge-case coverage relocated from the former test_coverage_100.py
 # ---------------------------------------------------------------------------
-
-
-class TestResolveInteractivePromptBumpExit:
-    """Tests for exception paths in release._resolve_interactive_prompt."""
-
-    def test_get_interactive_bump_raises_exit(self):
-        """release.py:338-339 – returns (False, None) when get_interactive_bump_type raises Exit."""
-        from rhiza_tools.commands.bump import Language
-        from rhiza_tools.commands.release import _resolve_interactive_prompt
-
-        mock_confirm = MagicMock()
-        mock_confirm.ask.return_value = True
-
-        with (
-            patch("questionary.confirm", return_value=mock_confirm),
-            patch("rhiza_tools.commands.release_versioning.get_current_version", return_value="1.0.0"),
-            patch(
-                "rhiza_tools.commands.release_versioning.get_interactive_bump_type",
-                side_effect=typer.Exit(),
-            ),
-        ):
-            result = _resolve_interactive_prompt(Language.PYTHON)
-
-        assert result == (False, None)
-
-    def test_get_interactive_bump_raises_eof(self):
-        """release.py:338-339 – returns (False, None) when get_interactive_bump_type raises EOFError."""
-        from rhiza_tools.commands.bump import Language
-        from rhiza_tools.commands.release import _resolve_interactive_prompt
-
-        mock_confirm = MagicMock()
-        mock_confirm.ask.return_value = True
-
-        with (
-            patch("questionary.confirm", return_value=mock_confirm),
-            patch("rhiza_tools.commands.release_versioning.get_current_version", return_value="1.0.0"),
-            patch(
-                "rhiza_tools.commands.release_versioning.get_interactive_bump_type",
-                side_effect=EOFError,
-            ),
-        ):
-            result = _resolve_interactive_prompt(Language.PYTHON)
-
-        assert result == (False, None)
 
 
 class TestValidateTagState:
@@ -1490,38 +1485,12 @@ def test_resolve_explicit_bump_type_invalid_bump_type():
         _resolve_explicit_bump_type("INVALID", Language.PYTHON)
 
 
-def test_resolve_interactive_prompt_user_declines():
-    """Test _resolve_interactive_prompt returns (False, None) when user declines bump."""
-    mock_confirm = MagicMock()
-    mock_confirm.ask.return_value = False
-
-    with patch("questionary.confirm", return_value=mock_confirm):
-        result = _resolve_interactive_prompt(Language.PYTHON)
-
-    assert result == (False, None)
-
-
-def test_resolve_interactive_prompt_bump_eof():
-    """Test _resolve_interactive_prompt returns (False, None) on EOFError."""
-    mock_confirm = MagicMock()
-    mock_confirm.ask.side_effect = EOFError
-
-    with patch("questionary.confirm", return_value=mock_confirm):
-        result = _resolve_interactive_prompt(Language.PYTHON)
-
-    assert result == (False, None)
-
-
-def test_resolve_interactive_prompt_bump_success():
-    """Test _resolve_interactive_prompt returns (True, new_version) when user accepts."""
-    mock_confirm = MagicMock()
-    mock_confirm.ask.return_value = True
-
+def test_resolve_required_bump_interactive_success():
+    """Test _resolve_required_bump returns (True, new_version) from the interactive prompt."""
     with (
-        patch("questionary.confirm", return_value=mock_confirm),
         patch("rhiza_tools.commands.release_versioning.get_current_version", return_value="1.0.0"),
         patch("rhiza_tools.commands.release_versioning.get_interactive_bump_type", return_value="1.1.0"),
     ):
-        result = _resolve_interactive_prompt(Language.PYTHON)
+        result = _resolve_required_bump(False, None, language=Language.PYTHON)
 
     assert result == (True, "1.1.0")

--- a/tests/test_versioning_guard_1126.py
+++ b/tests/test_versioning_guard_1126.py
@@ -222,6 +222,9 @@ def test_release_allows_stale_version_with_override(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     _patch_remote_latest(monkeypatch, "0.4.0")
 
-    with patch("rhiza_tools.commands.release_git.run_git_command", side_effect=_release_git_mock()):
+    with (
+        patch("rhiza_tools.commands.release_git.run_git_command", side_effect=_release_git_mock()),
+        patch("rhiza_tools.commands.release_versioning.bump_command"),
+    ):
         # Should complete the dry-run without raising for the monotonicity guard.
         release_mod.release_command(non_interactive=True, dry_run=True, allow_older=True)


### PR DESCRIPTION
## Summary

`rhiza-tools release` now **always bumps** the version before tagging. There is no tag-only release path and no yes/no "would you like to bump?" gate.

The bump type is resolved, in precedence order:
1. explicit `--bump MAJOR|MINOR|PATCH`
2. interactive bump-type selection (default in a TTY)
3. patch, when running `--non-interactive` without a `--bump` type

Cancelling the interactive selection now **aborts** the release — you cannot release without bumping.

## Why

The old `--with-bump` flag existed only to skip a yes/no confirm whose default was *don't bump*. That made "no bump" the implicit default, the opposite of what a release should do, and split the release into two commands (`release` / `release --with-bump`, surfaced in rhiza as `make release` / `make publish`). Always-bump collapses that to one path.

## Changes

- Remove the `--with-bump` CLI option and the `with_bump` parameter on `release_command()`.
- Replace `_get_bump_type_interactively()` with `_resolve_required_bump()` — drops the `dry_run`/`with_bump` params and always returns a concrete `(True, version)`.
- Delete the now-unreachable `_resolve_interactive_prompt()` and `_resolve_with_bump_flag()` helpers and the dead no-bump branches in `release_command()`.
- Tighten bump-resolution return types to `tuple[bool, str]`.
- Rewrite/trim the release tests for always-bump behavior.

## Pairing

Pairs with a rhiza-side change that drops the redundant `make publish` target and the release workflow's separate `update-changelog` job. The version-bump commit (with its git-cliff–folded `CHANGELOG.md`) becomes the single release commit.

## Verification

- `make fmt` ✅  `make typecheck` ✅
- `make test` ✅ — 441 passed, 99.12% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)