### PR TITLE
chore: add Claude Code project config

### DIFF
--- a/.claude/commands/quality.md
+++ b/.claude/commands/quality.md
@@ -11,6 +11,12 @@ fast failures surface before the slow test suite — and collect results:
 4. `make validate` — validate project structure against the Rhiza template.
 5. `make test` — full test suite.
 
+**Coverage expectation: 100%.** Treat anything below 100% line coverage on
+locally-owned `src/` as a gap to flag, not an acceptable baseline — the gate is
+set to 100 (`COVERAGE_FAIL_UNDER`). When scoring the test-coverage subcategory,
+100% is the bar for a 10; report every uncovered line (file:line) and what test
+would close it.
+
 Then report:
 
 - A pass/fail summary per step.

--- a/.claude/commands/quality.md
+++ b/.claude/commands/quality.md
@@ -1,0 +1,53 @@
+---
+description: Run lint, type, and test checks and summarize what to fix
+---
+
+Assess the quality of this repo. Run these in order — cheapest checks first so
+fast failures surface before the slow test suite — and collect results:
+
+1. `make fmt` — pre-commit hooks + linting (ruff).
+2. `make typecheck` — `ty` type checking.
+3. `make test` — full test suite.
+
+Then report:
+
+- A pass/fail summary per step.
+- Failures grouped by file, with the specific rule/error and line.
+- A prioritized list of what to fix first (blocking errors before style nits).
+
+Then analyse the repo and give marks on a scale of 1 to 10 for all relevant
+subcategories. Pick the subcategories that fit what you actually observe — e.g.
+linting/style, type safety, test pass rate, test coverage & depth, code
+structure & readability, documentation, dependency & security hygiene, CI/tooling
+health. For each: the score, a one-line justification grounded in evidence from
+the checks above (and a quick look at the code where needed), and what would
+raise it. Close with an overall score and the single highest-leverage
+improvement.
+
+**Scope the scorecard to locally-owned items — not what the mother repo (Rhiza)
+owns.** This project syncs its dev infrastructure from `jebel-quant/rhiza` (see
+`CLAUDE.md` for the authoritative split; the machine-generated list is the
+`files:` block of `.rhiza/template.lock`). Score only the things this repo
+actually controls — `src/rhiza_tools/`, `tests/`, `pyproject.toml`, `README.md`,
+project-specific docs, `.rhiza/template.yml`, and locally-hardened config like
+`ruff.toml`. Do **not** let Rhiza-managed files (the `.github/workflows/*`,
+`Makefile`, `.pre-commit-config.yaml`, `pytest.ini`, the `ty`/typecheck target,
+mutation/fuzzing/scorecard CI, etc.) drive the marks — a gap there is fixed
+upstream in Rhiza, not here. If a relevant signal is Rhiza-owned, note it as
+"upstream/out-of-scope" rather than scoring it against this repo.
+
+Then, from the scorecard above, identify **actionable issues to improve the
+score** — one per subcategory scoring below 10 (skip any that are maxed). For
+each, give: a concrete title, the subcategory and current→target score it moves,
+the specific file(s)/lines or config to change, and a crisp acceptance criterion
+("done when…"). Keep them in-scope (locally-owned, per the scoping rule above) —
+flag anything Rhiza-owned as upstream rather than listing it as a local action.
+Order them by leverage (biggest score gain for least effort first). This is a
+list of recommendations only — do not create GitHub issues or change code unless
+I explicitly ask.
+
+If everything passes, say so plainly — but still produce the 1–10 subcategory
+marks. Do not fix anything unless I ask — this command only assesses.
+
+If I passed an argument ($ARGUMENTS), scope the assessment to that path or topic
+instead of the whole repo.

--- a/.claude/commands/quality.md
+++ b/.claude/commands/quality.md
@@ -7,7 +7,9 @@ fast failures surface before the slow test suite — and collect results:
 
 1. `make fmt` — pre-commit hooks + linting (ruff).
 2. `make typecheck` — `ty` type checking.
-3. `make test` — full test suite.
+3. `make docs-coverage` — docstring coverage (interrogate).
+4. `make validate` — validate project structure against the Rhiza template.
+5. `make test` — full test suite.
 
 Then report:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and human contributors) working in this repository.
+
+## What is this repo?
+
+`rhiza-tools` provides the release/versioning tooling used by Rhiza-managed
+projects — version bumping, release, rollback, the CI version matrix, and badge
+generation. Its own development infrastructure is synced from Rhiza.
+
+## Rhiza-managed files — do NOT edit directly
+
+This project syncs its development infrastructure from the **Rhiza** template repo
+(`jebel-quant/rhiza`) via `rhiza-cli`. The configuration lives in
+[`.rhiza/template.yml`](.rhiza/template.yml) (profile `github-project` + the `legal`
+template).
+
+**The files below are owned by Rhiza. Do not edit them directly here** — any local
+change is overwritten on the next sync. To change one of them:
+
+1. Make the change **upstream** in `jebel-quant/rhiza` (the relevant
+   `bundles/<bundle>/...` source).
+2. Cut a new Rhiza release.
+3. Bump `ref:` in [`.rhiza/template.yml`](.rhiza/template.yml) here and run
+   **`make sync`** (which invokes `rhiza sync`).
+
+The authoritative, machine-generated list is the `files:` block of
+[`.rhiza/template.lock`](.rhiza/template.lock), refreshed on every sync. Current
+snapshot:
+
+### Root
+`.bandit`, `.editorconfig`, `.gitignore`, `.pre-commit-config.yaml`,
+`.python-version`, `LICENSE`, `Makefile`, `SECURITY.md`, `pytest.ini`, `ruff.toml`
+
+### `.github/`
+- Workflows: `rhiza_benchmark.yml`, `rhiza_book.yml`, `rhiza_ci.yml`,
+  `rhiza_codeql.yml`, `rhiza_marimo.yml`, `rhiza_release.yml`, `rhiza_sync.yml`,
+  `rhiza_weekly.yml`, `rhiza_fuzzing.yml`, `rhiza_scorecard.yml`,
+  `rhiza_mutation.yml` (opt-in mutation gate — `MUTATION_ENABLED`)
+- `rulesets/main-branch-protection.json`, `rulesets/README.md` (branch
+  protection — shipped by the `github` bundle)
+- `dependabot.yml`, `release.yml`, `secret_scanning.yml`,
+  `pull_request_template.md`
+- `DISCUSSION_TEMPLATE/`, `ISSUE_TEMPLATE/`
+
+> The list reflects the **current** rhiza template. This repo is pinned to an
+> older `ref:`, so its `.rhiza/template.lock` snapshot is smaller — the extra
+> files (`rhiza_fuzzing.yml`, `rhiza_scorecard.yml`, `rhiza_mutation.yml`,
+> `.github/rulesets/*`) only land once you bump `ref:` and run `make sync`.
+
+### `.rhiza/` (the sync engine — treat the whole directory as managed)
+- `rhiza.mk`, `make.d/*.mk`, `requirements/*.txt`, `semgrep.yml`,
+  `.cfg.toml`, `.env`, `.gitignore`, `.rhiza-version`
+- `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `assets/`, `completions/`
+- `tests/**` (the synced template test-suite), `utils/pip_audit_policy.py`,
+  `utils/suppression_audit.py`
+- **Owned by you:** `.rhiza/template.yml` (and `.rhiza/template.lock`, which the
+  tool regenerates).
+
+### `docs/`
+`docs/assets/rhiza-logo.svg`, `docs/development/MARIMO.md`,
+`docs/development/TESTS.md`, `docs/index.md`, `docs/mkdocs-base.yml`
+
+## Locally owned (safe to edit)
+
+Everything **not** listed above — notably `pyproject.toml`, `README.md`, `uv.lock`,
+`src/rhiza_tools/`, your own `tests/`, project-specific docs, and
+`.rhiza/template.yml`. Project-specific Make hooks (`pre-install::`,
+`post-install::`, …) go in the thin root `Makefile` above the `include` line.
+
+> ⚠️ `.github/rulesets/main-branch-protection.json` is **no longer locally
+> owned** — branch protection now ships via the `github` bundle. This repo's
+> richer, matrix-specific ruleset will conflict on sync; either fold the generic
+> parts upstream into rhiza or `exclude:` the bundle copy in `.rhiza/template.yml`
+> to keep the local one. Same situation as `ruff.toml` (locally hardened here).


### PR DESCRIPTION
Adds local Claude Code configuration to the repo:

- **`.claude/commands/quality.md`** — the `/quality` slash command. Runs `make fmt` → `make typecheck` → `make test` (cheapest first), reports pass/fail + failures by file, then produces a 1–10 scorecard **scoped to locally-owned items** (excludes Rhiza-managed files) and a leverage-ordered list of actionable improvements. Assess-only; never edits code.
- **`CLAUDE.md`** — project guidance (the Rhiza-managed vs. locally-owned file split, etc.).

Both were previously untracked local additions. No source, test, or CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)