### PR TITLE
chore: complete deptry package_module_name_map

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,12 +72,21 @@ error-on-warning = true
 
 [tool.deptry.package_module_name_map]
 "bump-my-version" = "bumpversion"
+"hypothesis" = "hypothesis"
 "loguru" = "loguru"
 "marimo" = "marimo"
+"mutmut" = "mutmut"
 "numpy" = "numpy"
 "pandas" = "pandas"
 "plotly" = "plotly"
+"prompt-toolkit" = "prompt_toolkit"
+"pytest" = "pytest"
+"pytest-cov" = "pytest_cov"
+"pytest-mock" = "pytest_mock"
+"pytest-timeout" = "pytest_timeout"
+"pytest-xdist" = "xdist"   # plugin imports as `xdist`, not `pytest_xdist`
 "questionary" = "questionary"
+"ruff" = "ruff"
 "semver" = "semver"
 "tomlkit" = "tomlkit"
 "typer" = "typer"


### PR DESCRIPTION
## Summary

Completes `[tool.deptry.package_module_name_map]` in `pyproject.toml` so `make deptry` runs without any `Assuming the corresponding module name of package 'X' is 'X'` info lines.

Previously deptry was guessing the import name for nine packages. They all resolved correctly (no findings), but the guessing left noisy output. This maps them explicitly.

## Changes

- Added: `prompt-toolkit`→`prompt_toolkit`, `pytest`, `pytest-cov`→`pytest_cov`, `pytest-mock`→`pytest_mock`, `pytest-timeout`→`pytest_timeout`, `pytest-xdist`→`xdist`, `hypothesis`, `mutmut`, `ruff`.
- `pytest-xdist` imports as `xdist` (not `pytest_xdist`) — verified, annotated inline.

## Verification

`make deptry` now emits **zero** `Assuming…` lines and still reports **"Success! No dependency issues found."**

Moves the *dependency & security hygiene* quality subcategory 9 → 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)