### PR TITLE
Fix: strip SLSA provenance from dist/ before PyPI publish

### DIFF
--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -417,6 +417,13 @@ jobs:
           fi
           cat "$GITHUB_OUTPUT"
 
+      - name: Remove non-distribution files before publish
+        # The dist artifact also carries the SLSA provenance bundle (staged for
+        # the GitHub release). twine/pypi-publish rejects it as an unknown
+        # distribution format, so strip it here before publishing.
+        if: ${{ steps.check_dist.outputs.should_publish == 'true' }}
+        run: rm -f dist/*.intoto.jsonl
+
       # this should not take place, as "Private :: Do Not Upload" set in pyproject.toml
       # repository-url and password only used for custom feeds, not for PyPI with OIDC
       - name: Publish to PyPI


### PR DESCRIPTION
## Problem

The release run fails `twine check` with:

```
Checking dist/provenance.intoto.jsonl: ERROR  InvalidDistribution: Unknown distribution format: 'provenance.intoto.jsonl'
```

The build job stages the SLSA provenance bundle into `dist/provenance.intoto.jsonl` (so it ships as a GitHub Release asset) and uploads the whole `dist/` dir as the `dist` artifact. The `pypi` job then points `pypa/gh-action-pypi-publish` at `packages-dir: dist/`, so `twine` walks every file in `dist/` and rejects the provenance bundle.

## Fix

Strip `dist/*.intoto.jsonl` in the `pypi` job, just before publishing. The `dist` artifact stays intact for the `draft-release` job; only PyPI sees real distributions.

> ⚠️ `rhiza_release.yml` is Rhiza-managed. This is a stopgap local edit to unblock releases — the durable fix lands upstream in `jebel-quant/rhiza` (companion PR) and replaces this on the next `make sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)