### PR TITLE
chore(fuzz): align .clusterfuzzlite with the rhiza-hooks build layout

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,14 +1,9 @@
-# ClusterFuzzLite build image for the rhiza-tools Atheris fuzz targets.
-# OSS-Fuzz publishes this base image only as :latest, so an explicit version
-# tag isn't available — silence hadolint's untagged-image / latest warnings.
-# hadolint ignore=DL3006,DL3007
-FROM gcr.io/oss-fuzz-base/base-builder-python
+# ClusterFuzzLite build image for rhiza-tools.
+# Uses the OSS-Fuzz Python base image, which provides Atheris and the
+# compile_python_fuzzer helper.
+# Pinned by SHA256 so the build image only changes through reviewed updates.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
 
-# Copy the whole repository into the OSS-Fuzz source tree.
-COPY . $SRC/rhiza-tools
-
-# Build commands run from the project root.
-WORKDIR $SRC/rhiza-tools
-
-# The build script is invoked by the OSS-Fuzz `compile` entrypoint.
-COPY .clusterfuzzlite/build.sh $SRC/
+COPY . $SRC
+WORKDIR $SRC
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,16 +1,19 @@
 #!/bin/bash -eu
-# Build script for ClusterFuzzLite / OSS-Fuzz.
-#
-# Installs the project so its modules are importable, then compiles every
-# Atheris fuzz target shipped under fuzzers/ into a standalone executable.
+# ClusterFuzzLite build script — installs rhiza_tools and compiles each Atheris
+# fuzz target under fuzzers/ via OSS-Fuzz's compile_python_fuzzer helper.
 
-# Install the package (and its dependencies) into the build image so the
-# fuzz targets can import rhiza_tools during PyInstaller analysis and at run
-# time.
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
+
+# Install the package and its runtime dependencies into the build environment so
+# PyInstaller can discover and bundle rhiza_tools into each frozen fuzz target.
+# compile_python_fuzzer names the resulting binary after the source file
+# (e.g. version_matrix_fuzzer.py -> version_matrix_fuzzer).
 pip3 install .
 
-# Compile each fuzz target. compile_python_fuzzer names the resulting binary
-# after the source file (e.g. version_matrix_fuzzer.py -> version_matrix_fuzzer).
-for fuzzer in "$SRC"/rhiza-tools/fuzzers/*_fuzzer.py; do
+for fuzzer in fuzzers/*_fuzzer.py; do
   compile_python_fuzzer "$fuzzer"
 done

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: python


### PR DESCRIPTION
Brings rhiza-tools' `.clusterfuzzlite/` in line with the improved build setup in `jebel-quant/rhiza-hooks`.

- **Add `project.yaml`** (`language: python`) — was missing.
- **Dockerfile**: SHA-pin the OSS-Fuzz base image; `COPY`/`WORKDIR` use `$SRC` directly instead of a hardcoded `$SRC/rhiza-tools` subdirectory.
- **build.sh**: `cd "$SRC"` (no project-name path), pin pip to `24.3.1`, and glob harnesses from `fuzzers/*_fuzzer.py`.

The existing `fuzzers/version_matrix_fuzzer.py` target is unchanged. Set the `FUZZING_ENABLED` repo variable to `true` so the `(RHIZA) FUZZING` workflow runs and verifies the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)