### PR TITLE
feat: add ClusterFuzzLite fuzzing scaffold for rhiza_tools

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-# ClusterFuzzLite build image for rhiza-tools.
+# ClusterFuzzLite build image for rhiza_tools.
 # Uses the OSS-Fuzz Python base image, which provides Atheris and the
 # compile_python_fuzzer helper.
 # Pinned by SHA256 so the build image only changes through reviewed updates.

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
-# ClusterFuzzLite build script — installs rhiza_tools and compiles each Atheris
-# fuzz target under fuzzers/ via OSS-Fuzz's compile_python_fuzzer helper.
+# ClusterFuzzLite build script — installs rhiza_tools and compiles each Python
+# harness in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
 
 cd "$SRC"
 
@@ -8,12 +8,12 @@ cd "$SRC"
 # reviewed bump (the same rationale as the SHA-pinned base image).
 pip3 install --upgrade "pip==24.3.1"
 
-# Install the package and its runtime dependencies into the build environment so
-# PyInstaller can discover and bundle rhiza_tools into each frozen fuzz target.
-# compile_python_fuzzer names the resulting binary after the source file
-# (e.g. version_matrix_fuzzer.py -> version_matrix_fuzzer).
+# Install the package and its runtime dependencies so PyInstaller can discover
+# and bundle rhiza_tools into each frozen fuzzer binary. The fuzz target only
+# touches the pure-Python version-matrix parser, so no compiled-extension
+# dependencies need a --collect-all here.
 pip3 install .
 
-for fuzzer in fuzzers/*_fuzzer.py; do
+for fuzzer in tests/fuzz/fuzz_*.py; do
   compile_python_fuzzer "$fuzzer"
 done

--- a/tests/fuzz/fuzz_version_matrix.py
+++ b/tests/fuzz/fuzz_version_matrix.py
@@ -1,0 +1,54 @@
+"""Fuzz the rhiza_tools version-matrix parser against arbitrary strings.
+
+``parse_version`` and ``satisfies`` parse untrusted version and specifier
+strings (e.g. from a project's ``pyproject.toml``). They are contracted to
+return a result or raise ``VersionSpecifierError`` on malformed input — never to
+crash with an unexpected exception. This harness exercises that contract with
+coverage-guided input.
+
+Run locally:
+    pip install atheris
+    python tests/fuzz/fuzz_version_matrix.py -atheris_runs=20000
+
+Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from rhiza_tools.commands.version_matrix import (
+        VersionSpecifierError,
+        parse_version,
+        satisfies,
+    )
+
+# The parsers are documented to raise only VersionSpecifierError on bad input.
+# Anything else propagates and is recorded by Atheris as a crash.
+_ALLOWED = (VersionSpecifierError,)
+
+
+def test_one_input(data: bytes) -> None:
+    """Parse fuzzed version/specifier strings."""
+    fdp = atheris.FuzzedDataProvider(data)
+    version = fdp.ConsumeUnicodeNoSurrogates(24)
+    specifier = fdp.ConsumeUnicodeNoSurrogates(48)
+
+    with contextlib.suppress(_ALLOWED):
+        parse_version(version)
+    with contextlib.suppress(_ALLOWED):
+        satisfies(version, specifier)
+
+
+def main() -> None:
+    """Run the Atheris fuzz loop."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the opt-in **ClusterFuzzLite** fuzzing scaffold so the existing `rhiza_fuzzing.yml` workflow actually runs.

- `.clusterfuzzlite/Dockerfile` — OSS-Fuzz Python base image, SHA-pinned
- `.clusterfuzzlite/build.sh` — installs `rhiza_tools` and compiles each `tests/fuzz/fuzz_*.py` harness (pure-Python target, no `--collect-all` needed)
- `tests/fuzz/fuzz_version_matrix.py` — Atheris harness fuzzing `parse_version()` and `satisfies()` with arbitrary version/specifier strings; they must raise only `VersionSpecifierError` on malformed input

`FUZZING_ENABLED` is already set to `true`.

## Test plan
- [x] Built **and run** locally against the OSS-Fuzz `base-builder-python` image — 4000 runs, no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
