### PR TITLE
refactor(cli): deduplicate --language parsing into shared helper

### DIFF
--- a/src/rhiza_tools/cli.py
+++ b/src/rhiza_tools/cli.py
@@ -31,7 +31,7 @@ from typing import Annotated
 
 import typer
 
-from rhiza_tools import __version__, console
+from rhiza_tools import __version__
 from rhiza_tools.console import configure as configure_console
 
 from .commands.analyze_benchmarks import analyze_benchmarks_command
@@ -150,17 +150,9 @@ def bump(
             $ rhiza-tools bump patch --config /path/to/my.cfg.toml
     """
     _apply_verbose(verbose)
-    from rhiza_tools.commands.bump import BumpOptions, Language
+    from rhiza_tools.commands.bump import BumpOptions, parse_language_option
 
-    # Parse language if provided
-    lang_enum = None
-    if language:
-        try:
-            lang_enum = Language(language.lower())
-        except ValueError:
-            console.error(f"Invalid language: {language}")
-            console.error("Supported languages: python, go")
-            raise typer.Exit(code=1) from None
+    lang_enum = parse_language_option(language)
 
     options = BumpOptions(
         version=version,
@@ -283,16 +275,9 @@ def release(
             $ rhiza-tools release --language go
     """
     _apply_verbose(verbose)
-    from rhiza_tools.commands.bump import Language
+    from rhiza_tools.commands.bump import parse_language_option
 
-    lang_enum = None
-    if language:
-        try:
-            lang_enum = Language(language.lower())
-        except ValueError:
-            console.error(f"Invalid language: {language}")
-            console.error("Supported languages: python, go")
-            raise typer.Exit(code=1) from None
+    lang_enum = parse_language_option(language)
 
     release_command(bump, push, dry_run, non_interactive, lang_enum, config, allow_older)
 

--- a/src/rhiza_tools/commands/bump/__init__.py
+++ b/src/rhiza_tools/commands/bump/__init__.py
@@ -53,6 +53,9 @@ from rhiza_tools.commands.bump.git import (
 from rhiza_tools.commands.bump.git import (
     _restore_original_branch as _restore_original_branch,
 )
+from rhiza_tools.commands.bump.io import (
+    SUPPORTED_LANGUAGES_MSG as SUPPORTED_LANGUAGES_MSG,
+)
 
 # Project I/O, interactive UI, and public data model live in bump/io.py; re-exported
 # here so callers and tests that use ``rhiza_tools.commands.bump.<name>`` keep working.
@@ -76,6 +79,9 @@ from rhiza_tools.commands.bump.io import (
 )
 from rhiza_tools.commands.bump.io import (
     get_interactive_bump_type as get_interactive_bump_type,
+)
+from rhiza_tools.commands.bump.io import (
+    parse_language_option as parse_language_option,
 )
 
 # Re-export pure version-math helpers so external callers and tests that reference
@@ -162,7 +168,7 @@ def _resolve_language(options: BumpOptions) -> Language:
         if detected_language is None:
             console.error("Unable to detect project language.")
             console.error("Please specify language explicitly with --language option.")
-            console.error("Supported languages: python, go")
+            console.error(SUPPORTED_LANGUAGES_MSG)
             raise typer.Exit(code=1)
         language = detected_language
         console.info(f"Detected language: {typer.style(language.value, fg=typer.colors.CYAN, bold=True)}")

--- a/src/rhiza_tools/commands/bump/io.py
+++ b/src/rhiza_tools/commands/bump/io.py
@@ -82,6 +82,35 @@ class Language(StrEnum):
         return Path("VERSION")
 
 
+# User-facing hint listing the languages accepted by ``--language``. Defined once
+# so the message stays consistent everywhere it is shown (invalid value, failed
+# auto-detection).
+SUPPORTED_LANGUAGES_MSG = "Supported languages: python, go"
+
+
+def parse_language_option(language: str | None) -> Language | None:
+    """Parse the ``--language`` CLI option into a :class:`Language`.
+
+    Args:
+        language: The raw ``--language`` value, or ``None`` when the option was
+            not supplied (auto-detection happens later).
+
+    Returns:
+        The matching :class:`Language`, or ``None`` when ``language`` is ``None``.
+
+    Raises:
+        typer.Exit: If ``language`` is given but is not a supported value.
+    """
+    if language is None:
+        return None
+    try:
+        return Language(language.lower())
+    except ValueError:
+        console.error(f"Invalid language: {language}")
+        console.error(SUPPORTED_LANGUAGES_MSG)
+        raise typer.Exit(code=1) from None
+
+
 @dataclass
 class BumpOptions:
     """Configuration options for bump command.


### PR DESCRIPTION
Closes #285

## What
The `bump` and `release` CLI commands in `src/rhiza_tools/cli.py` each contained a byte-identical try/except block parsing the `--language` option, and the user-facing hint `"Supported languages: python, go"` was duplicated in three places.

## Changes
- Add `parse_language_option(language: str | None) -> Language | None` and a module-level `SUPPORTED_LANGUAGES_MSG` constant in `commands/bump/io.py` (next to the `Language` enum).
- Re-export both from the `commands.bump` package.
- Call the helper from both CLI commands; drop the now-unused `console` import in `cli.py`.
- Reuse `SUPPORTED_LANGUAGES_MSG` in the auto-detection failure path of `_resolve_language`.

## Verification
`make fmt`, `make typecheck` (ty + mypy --strict), and `make test` all green; coverage remains 100% (455 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)