### PR TITLE
refactor(version-matrix): hoist default Python candidates into a constant

### DIFF
--- a/src/rhiza_tools/commands/version_matrix.py
+++ b/src/rhiza_tools/commands/version_matrix.py
@@ -24,6 +24,11 @@ from pathlib import Path
 
 from rhiza_tools import console
 
+# Candidate Python versions evaluated against ``requires-python`` when the caller
+# does not pass an explicit list. Single source of truth so the runtime default
+# and the docstrings that mention it cannot drift apart.
+DEFAULT_PYTHON_CANDIDATES = ["3.11", "3.12", "3.13", "3.14"]
+
 
 class RhizaError(Exception):
     """Base exception for Rhiza-related errors."""
@@ -223,7 +228,7 @@ def version_matrix_command(
     Args:
         pyproject_path: Path to pyproject.toml. Defaults to ./pyproject.toml.
         candidates: List of candidate Python versions to evaluate. Defaults to
-            ["3.11", "3.12", "3.13", "3.14"].
+            :data:`DEFAULT_PYTHON_CANDIDATES`.
 
     Raises:
         SystemExit: If pyproject.toml is missing, invalid, or no versions match.
@@ -246,7 +251,7 @@ def version_matrix_command(
         pyproject_path = Path("pyproject.toml")
 
     if candidates is None:
-        candidates = ["3.11", "3.12", "3.13", "3.14"]
+        candidates = list(DEFAULT_PYTHON_CANDIDATES)
 
     try:
         versions = get_supported_versions(pyproject_path, candidates)


### PR DESCRIPTION
Closes #286

## What
The default candidate Python versions `["3.11", "3.12", "3.13", "3.14"]` were hardcoded in the runtime default of `version_matrix_command` and restated verbatim in a docstring, creating a drift risk when the supported set changes.

## Changes
- Add module-level `DEFAULT_PYTHON_CANDIDATES` in `commands/version_matrix.py`.
- Use it (via a defensive copy) as the runtime default.
- Reference the constant in the command docstring instead of repeating the literal.

## Verification
`make fmt`, `make typecheck` (ty + mypy --strict), `make docs-coverage` (100%), and `make test` all green; coverage remains 100% (455 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)