### PR TITLE
refactor(commands): unify semver parse-and-exit into shared helper

### DIFF
--- a/src/rhiza_tools/commands/_shared.py
+++ b/src/rhiza_tools/commands/_shared.py
@@ -165,6 +165,34 @@ def get_latest_remote_version(remote: str = "origin") -> semver.Version | None:
     return max(versions) if versions else None
 
 
+def parse_semver_or_exit(version_str: str, *, strip_v_prefix: bool = False) -> semver.Version:
+    """Parse a semantic version string, exiting with a consistent error on failure.
+
+    Centralises the parse-and-exit pattern that several commands previously
+    duplicated, so an unparseable version is always reported the same way.
+
+    Args:
+        version_str: The version to parse (e.g. ``"1.2.3"`` or ``"v1.2.3"``).
+        strip_v_prefix: If True, drop a leading ``"v"`` before parsing.
+
+    Returns:
+        The parsed :class:`semver.Version`.
+
+    Raises:
+        typer.Exit: If ``version_str`` is not a valid semantic version.
+
+    Example:
+        >>> parse_semver_or_exit("1.2.3")  # doctest: +SKIP
+        Version(major=1, minor=2, patch=3, ...)
+    """
+    candidate = version_str[1:] if strip_v_prefix and version_str.startswith("v") else version_str
+    try:
+        return semver.Version.parse(candidate)
+    except ValueError:
+        console.error(f"Invalid semantic version: {version_str}")
+        raise typer.Exit(code=1) from None
+
+
 def validate_pyproject_exists() -> None:
     """Validate that pyproject.toml exists in the current directory.
 

--- a/src/rhiza_tools/commands/bump/io.py
+++ b/src/rhiza_tools/commands/bump/io.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import cast
 
 import questionary as qs
-import semver
 import typer
 from loguru import logger
 
@@ -27,6 +26,7 @@ from rhiza_tools import console
 from rhiza_tools.commands._shared import (
     COOL_STYLE,
     NON_INTERACTIVE_ERRORS,
+    parse_semver_or_exit,
 )
 from rhiza_tools.commands.bump.engine import BumpConfig, _get_files_to_modify
 from rhiza_tools.commands.bump.versioning import (
@@ -181,11 +181,7 @@ def get_interactive_bump_type(current_version_str: str) -> str:
               Major (1.0.0 -> 2.0.0)
               ...
     """
-    try:
-        current_version = semver.Version.parse(current_version_str)
-    except ValueError:
-        console.error(f"Invalid semantic version in configuration: {current_version_str}")
-        raise typer.Exit(code=1) from None
+    current_version = parse_semver_or_exit(current_version_str)
 
     next_patch = current_version.bump_patch()
     next_minor = current_version.bump_minor()

--- a/src/rhiza_tools/commands/bump/versioning.py
+++ b/src/rhiza_tools/commands/bump/versioning.py
@@ -13,6 +13,7 @@ import semver
 import typer
 
 from rhiza_tools import console
+from rhiza_tools.commands._shared import parse_semver_or_exit
 
 
 def _denormalize_pep440_to_semver(version_str: str) -> str:
@@ -204,11 +205,7 @@ def _parse_version_argument(version: str | None, current_version_str: str) -> st
     if not version:
         return ""
 
-    try:
-        current_version = semver.Version.parse(current_version_str)
-    except ValueError:
-        console.error(f"Invalid semantic version: {current_version_str}")
-        raise typer.Exit(code=1) from None
+    current_version = parse_semver_or_exit(current_version_str)
 
     # Try to get bumped version from type keyword
     bumped_version = get_bumped_version_from_type(current_version, version)

--- a/src/rhiza_tools/commands/release/__init__.py
+++ b/src/rhiza_tools/commands/release/__init__.py
@@ -24,12 +24,12 @@ Example:
 
 from pathlib import Path
 
-import semver
 import typer
 
 from rhiza_tools import console
 from rhiza_tools.commands._shared import (
     get_latest_remote_version,
+    parse_semver_or_exit,
 )
 from rhiza_tools.commands._shared import (
     run_git_command as run_git_command,
@@ -171,11 +171,7 @@ def _check_release_version_monotonic(version_str: str, allow_older: bool) -> Non
     if latest_remote is None:
         return
 
-    try:
-        candidate = semver.Version.parse(version_str[1:] if version_str.startswith("v") else version_str)
-    except ValueError:
-        console.error(f"Invalid semantic version: {version_str}")
-        raise typer.Exit(code=1) from None
+    candidate = parse_semver_or_exit(version_str, strip_v_prefix=True)
 
     if candidate > latest_remote:
         console.success(f"Preflight: v{candidate} is newer than the latest remote release v{latest_remote}")

--- a/src/rhiza_tools/commands/release/versioning.py
+++ b/src/rhiza_tools/commands/release/versioning.py
@@ -9,10 +9,10 @@ re-exports these helpers, so the public import surface is unchanged.
 
 from pathlib import Path
 
-import semver
 import typer
 
 from rhiza_tools import console
+from rhiza_tools.commands._shared import parse_semver_or_exit
 from rhiza_tools.commands.bump import (
     BumpOptions,
     Language,
@@ -49,7 +49,7 @@ def _resolve_required_bump(non_interactive: bool, bump_type: str | None, *, lang
 
     if non_interactive:
         console.warning("No --bump type given in non-interactive mode, defaulting to patch")
-        current_semver = semver.Version.parse(current_version_str)
+        current_semver = parse_semver_or_exit(current_version_str)
         return True, str(current_semver.bump_patch())
 
     return True, get_interactive_bump_type(current_version_str)
@@ -69,11 +69,7 @@ def _resolve_explicit_bump_type(bump_type: str, language: Language) -> tuple[boo
         typer.Exit: If the current version is invalid or the bump type is unsupported.
     """
     current_version_str = _resolve_bump_baseline(get_current_version(language))
-    try:
-        current_semver = semver.Version.parse(current_version_str)
-    except ValueError:
-        console.error(f"Invalid semantic version: {current_version_str}")
-        raise typer.Exit(code=1) from None
+    current_semver = parse_semver_or_exit(current_version_str)
     new_version = get_bumped_version_from_type(current_semver, bump_type.lower())
     if not new_version:
         console.error(f"Invalid bump type: {bump_type}")


### PR DESCRIPTION
Closes #287

## What
Several command modules independently parsed a version string with `semver.Version.parse`, caught `ValueError`, logged an error, and raised `typer.Exit`. The user-facing messages were slightly inconsistent (`"Invalid semantic version: ..."` vs `"Invalid semantic version in configuration: ..."`).

## Changes
- Add `parse_semver_or_exit(version_str, *, strip_v_prefix=False)` to `commands/_shared.py`, returning the parsed `semver.Version` and emitting one consistent error on failure.
- Route the duplicated parse-and-exit sites through it:
  - `commands/release/versioning.py` (both the explicit-bump path and the non-interactive patch default)
  - `commands/release/__init__.py` (preflight check, with `strip_v_prefix=True`)
  - `commands/bump/versioning.py` (`_parse_version_argument`)
  - `commands/bump/io.py` (`get_interactive_bump_type`)
- Drop the now-unused `semver` imports in the release modules and `bump/io.py`.

The `_validate_explicit_version` site in `bump/versioning.py` keeps its distinct "Invalid version format / please use a valid semantic version" guidance, as it validates user-supplied explicit input rather than a current version.

## Verification
`make fmt`, `make typecheck` (ty + mypy --strict), and `make test` all green; coverage remains 100% (455 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)