### PR TITLE
Fix for Empty except

### DIFF
--- a/src/rhiza_tools/commands/rollback/git.py
+++ b/src/rhiza_tools/commands/rollback/git.py
@@ -100,7 +100,8 @@ def _get_previous_version_from_tags(current_tag: str) -> str | None:
         if idx + 1 < len(tags):
             return tags[idx + 1]
     except ValueError:
-        pass
+        # current_tag is not present in the version-sorted tag list.
+        return None
 
     return None
 


### PR DESCRIPTION
General fix: replace bare `except ...: pass` with explicit handling that documents intent and keeps behavior unchanged.

Best fix here: in `src/rhiza_tools/commands/rollback/git.py`, update the `except ValueError:` block in `_get_previous_version_from_tags` to return `None` directly and add a short explanatory comment. This preserves existing functionality (the function already returns `None` after the try/except) while making the control flow explicit and satisfying the rule.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._