### PR TITLE
fix: combine three Copilot autofix findings (#300, #301, #302)

### DIFF
--- a/.rhiza/tests/api/test_releasing_targets.py
+++ b/.rhiza/tests/api/test_releasing_targets.py
@@ -23,7 +23,7 @@ class TestReleasingTargets:
     """Smoke tests for the releasing.mk targets."""
 
     def test_changelog_target_dry_run(self, logger):
-        """Changelog target should generate CHANGELOG.md via git-cliff in dry-run output."""
+        """Changelog target should generate CHANGELOG.md via git-cliff in dry run output."""
         proc = run_make(logger, ["changelog"])
         out = proc.stdout
         assert "no rule to make target" not in proc.stderr.lower()

--- a/src/rhiza_tools/commands/release/versioning.py
+++ b/src/rhiza_tools/commands/release/versioning.py
@@ -78,7 +78,7 @@ def _resolve_explicit_bump_type(bump_type: str, language: Language) -> str:
     current_semver = parse_semver_or_exit(current_version_str)
     new_version = get_bumped_version_from_type(current_semver, bump_type.lower())
     if not new_version:
-        console.error(f"Invalid bump type: {bump_type}. Valid bump types are: major, minor, patch.")
+        console.error(f"Invalid bump type: {bump_type}. Valid bump types (case-insensitive) are: major, minor, patch.")
         raise typer.Exit(code=1)
     return new_version
 

--- a/src/rhiza_tools/commands/rollback/git.py
+++ b/src/rhiza_tools/commands/rollback/git.py
@@ -14,6 +14,9 @@ from rhiza_tools.commands._shared import run_git_command
 # Number of fields in the `%H|%ci|%s` git-show format (commit hash, date, subject).
 _TAG_DETAIL_FIELDS = 3
 
+# Keywords used to identify version bump commits from commit subjects.
+_BUMP_KEYWORDS = ["bump version", "bump:", "version bump", "release version", "chore: bump"]
+
 
 def _get_tag_commit(tag: str) -> str | None:
     """Get the commit hash that a tag points to.
@@ -73,8 +76,7 @@ def _is_bump_commit(tag: str) -> bool:
         return False
 
     message = result.stdout.strip().lower()
-    bump_keywords = ["bump version", "bump:", "version bump", "release version", "chore: bump"]
-    return any(keyword in message for keyword in bump_keywords)
+    return any(keyword in message for keyword in _BUMP_KEYWORDS)
 
 
 def _get_previous_version_from_tags(current_tag: str) -> str | None:
@@ -93,7 +95,11 @@ def _get_previous_version_from_tags(current_tag: str) -> str | None:
     if result.returncode != 0 or not result.stdout.strip():
         return None
 
-    tags = [t.strip() for t in result.stdout.strip().split("\n") if t.strip()]
+    tags: list[str] = []
+    for t in result.stdout.strip().split("\n"):
+        stripped = t.strip()
+        if stripped:
+            tags.append(stripped)
 
     try:
         idx = tags.index(current_tag)
@@ -103,6 +109,7 @@ def _get_previous_version_from_tags(current_tag: str) -> str | None:
         # current_tag is not present in the version-sorted tag list.
         return None
 
+    # current_tag is the oldest tag, so there is no previous version.
     return None
 
 


### PR DESCRIPTION
Consolidates the three open `ai-findings-autofix` PRs into a single change set, with the CI failures from the original autofixes corrected.

## Changes

| Source PR | File | Fix |
|-----------|------|-----|
| #300 | `src/rhiza_tools/commands/rollback/git.py` | Restore the trailing `return None` the autofix dropped from `_get_previous_version_from_tags` — the oldest-tag fall-through path had no return, which `mypy --strict` flagged as **"Missing return statement"**. |
| #301 | `src/rhiza_tools/commands/release/versioning.py` | Apply `ruff format` to the reworded "Invalid bump type" error message — the autofix's hand-wrap failed the **pre-commit** hook. |
| #302 | `.rhiza/tests/api/test_releasing_targets.py` | Docstring wording tweak (`dry-run` → `dry run`). ⚠️ This is a **Rhiza-managed** file and will be overwritten on the next template sync. |

## Verification

Locally green: `ruff format --check`, `ruff check`, and `mypy --strict` on all touched files.

Supersedes and closes #300, #301, #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)