### PR TITLE
feat: add pip-audit and suppression-audit commands (rhiza#1377)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,51 @@ rhiza-tools analyze-benchmarks \
 *   `--benchmarks-json PATH` - Path to benchmarks.json file (default: `_benchmarks/benchmarks.json`).
 *   `--output-html PATH` - Path to save HTML visualization (default: `_benchmarks/benchmarks.html`).
 
+### `pip-audit`
+
+Run `pip-audit` with a tiered vulnerability policy. Vulnerabilities in runtime
+dependencies fail the command; findings in build tooling (`pip`, `setuptools`,
+`wheel`, `distribute`) warn without failing. Any arguments after the command are
+forwarded verbatim to `pip-audit`.
+
+**Usage:**
+
+```bash
+# Audit the current environment
+rhiza-tools pip-audit
+
+# Forward flags through to pip-audit
+rhiza-tools pip-audit --ignore-vuln CVE-2024-1234
+```
+
+**Options:**
+
+*   `--verbose`, `-v` - Show verbose debug output.
+*   Any other arguments are forwarded to `pip-audit`.
+
+### `suppression-audit`
+
+Scan the codebase for inline suppression comments (`# noqa`, `# nosec`,
+`# type: ignore`, `# pragma: no cover`, `# noinspection`) and print a per-file
+report, an ASCII histogram, and a suppression-density letter grade.
+
+**Usage:**
+
+```bash
+# Report suppressions and grade
+rhiza-tools suppression-audit
+
+# Also fail on stale CVE-tagged # nosec comments
+rhiza-tools suppression-audit --fail-stale-nosec-cve
+```
+
+**Options:**
+
+*   `--fail-stale-nosec-cve` - Fail when `# nosec` comments reference CVEs that
+    `pip-audit` no longer reports.
+*   `--verbose`, `-v` - Show verbose debug output.
+*   Any other arguments are forwarded to `pip-audit` (for the stale-CVE gate).
+
 ## Development
 
 ### Prerequisites

--- a/src/rhiza_tools/cli.py
+++ b/src/rhiza_tools/cli.py
@@ -20,8 +20,10 @@ from rhiza_tools.console import configure as configure_console
 from .commands.analyze_benchmarks import analyze_benchmarks_command
 from .commands.bump import bump_command
 from .commands.generate_badge import generate_coverage_badge_command
+from .commands.pip_audit import pip_audit_command
 from .commands.release import release_command
 from .commands.rollback import rollback_command
+from .commands.suppression import suppression_audit_command
 from .commands.update_readme import update_readme_command
 from .commands.version_matrix import version_matrix_command
 
@@ -337,3 +339,53 @@ def analyze_benchmarks(
     """
     _apply_verbose(verbose)
     analyze_benchmarks_command(benchmarks_json=benchmarks_json, output_html=output_html, show=show)
+
+
+@app.command(
+    name="pip-audit",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def pip_audit(ctx: typer.Context, verbose: bool = VERBOSE_OPTION) -> None:
+    """Run pip-audit with a tiered vulnerability policy.
+
+    Vulnerabilities in runtime dependencies fail the command; findings in build
+    tooling (pip, setuptools, wheel, distribute) warn without failing. Any extra
+    arguments after the command are forwarded verbatim to pip-audit
+    (e.g. ``rhiza-tools pip-audit --ignore-vuln CVE-2024-1234``).
+
+    Args:
+        ctx: Typer context; its extra args are forwarded verbatim to pip-audit.
+        verbose: If True, enable verbose debug output.
+    """
+    _apply_verbose(verbose)
+    raise typer.Exit(code=pip_audit_command(ctx.args))
+
+
+@app.command(
+    name="suppression-audit",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def suppression_audit(
+    ctx: typer.Context,
+    fail_stale_nosec_cve: bool = typer.Option(
+        False,
+        "--fail-stale-nosec-cve",
+        help="Fail when # nosec comments reference CVEs that pip-audit no longer reports.",
+    ),
+    verbose: bool = VERBOSE_OPTION,
+) -> None:
+    """Scan the codebase for inline suppressions and report a density grade.
+
+    Detects inline suppression comments (# noqa, # nosec, # type: ignore,
+    # pragma: no cover, # noinspection), and prints a per-file report, an ASCII
+    histogram, and a letter grade. With ``--fail-stale-nosec-cve`` it also
+    cross-checks CVE-tagged # nosec comments against live pip-audit findings and
+    fails on stale ones; extra arguments are forwarded to pip-audit.
+
+    Args:
+        ctx: Typer context; its extra args are forwarded to pip-audit.
+        fail_stale_nosec_cve: If True, fail on stale CVE-tagged # nosec comments.
+        verbose: If True, enable verbose debug output.
+    """
+    _apply_verbose(verbose)
+    raise typer.Exit(code=suppression_audit_command(fail_stale_nosec_cve, ctx.args))

--- a/src/rhiza_tools/commands/pip_audit.py
+++ b/src/rhiza_tools/commands/pip_audit.py
@@ -1,0 +1,97 @@
+"""Run pip-audit with a tiered vulnerability policy.
+
+Fails for vulnerabilities in runtime dependencies. Warns (without failing) for
+build tooling: pip, setuptools, wheel, distribute. Any extra arguments are
+forwarded to pip-audit (e.g. ``--ignore-vuln CVE-XXXX-YYYY``).
+
+The rendering here uses ANSI-coloured ``print`` output rather than the shared
+``console`` helpers: this command emits a self-contained CI report whose colour
+scheme (green OK / yellow WARN / red FAIL) is part of its contract.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # nosec B404
+import sys
+
+_RESET = "\033[0m"
+_RED = "\033[31m"
+_YELLOW = "\033[33m"
+_GREEN = "\033[32m"
+
+# Packages treated as build tooling — CVEs warn but do not fail CI.
+_TOOLING: frozenset[str] = frozenset({"pip", "setuptools", "wheel", "distribute"})
+
+
+def _vuln_ids(vuln: dict) -> str:  # type: ignore[type-arg]
+    """Return a human-readable string of all IDs for a vulnerability entry.
+
+    Args:
+        vuln: A single vulnerability object from pip-audit's JSON output. Must
+            contain an ``id`` key and may contain an ``aliases`` list.
+
+    Returns:
+        A comma-separated string starting with the primary ``id`` followed by any
+        distinct aliases (e.g. ``"PYSEC-2024-1, CVE-2024-1234"``).
+    """
+    ids = [vuln["id"]] + [a for a in vuln.get("aliases", []) if a != vuln["id"]]
+    return ", ".join(ids)
+
+
+def pip_audit_command(extra_args: list[str]) -> int:
+    """Run pip-audit and apply the tiered vulnerability policy.
+
+    Invokes ``uvx pip-audit`` with JSON output, forwarding ``extra_args``.
+    Vulnerabilities in build tooling (see ``_TOOLING``) are reported as
+    warnings; vulnerabilities in any other (runtime) dependency are reported as
+    failures.
+
+    Args:
+        extra_args: Additional arguments forwarded verbatim to pip-audit
+            (e.g. ``["--ignore-vuln", "CVE-2024-1234"]``).
+
+    Returns:
+        A process exit code: ``0`` when no vulnerabilities affect runtime
+        dependencies (clean run, tooling-only findings, or unparseable output is
+        passed through with pip-audit's own code), or ``1`` when at least one
+        runtime dependency is vulnerable.
+
+    Example:
+        Forward flags through to pip-audit::
+
+            pip_audit_command(["--ignore-vuln", "CVE-2024-1234"])
+    """
+    uvx = shutil.which("uvx") or "uvx"
+    cmd = [uvx, "pip-audit", "--format", "json", *extra_args]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)  # nosec B603 - uvx/pip-audit is trusted  # noqa: S603
+
+    if proc.returncode == 0:
+        print(f"{_GREEN}[OK] pip-audit: no vulnerabilities found{_RESET}")
+        return 0
+
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        sys.stdout.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+        return proc.returncode
+
+    deps = data.get("dependencies", [])
+    tooling_vulns = [d for d in deps if d.get("vulns") and d["name"].lower() in _TOOLING]
+    runtime_vulns = [d for d in deps if d.get("vulns") and d["name"].lower() not in _TOOLING]
+
+    for dep in tooling_vulns:
+        for v in dep["vulns"]:
+            print(
+                f"{_YELLOW}[WARN] {dep['name']}=={dep['version']}: {_vuln_ids(v)} (tooling — not failing build){_RESET}"
+            )
+
+    if not runtime_vulns:
+        return 0
+
+    for dep in runtime_vulns:
+        for v in dep["vulns"]:
+            print(f"{_RED}[FAIL] {dep['name']}=={dep['version']}: {_vuln_ids(v)}{_RESET}")
+    return 1

--- a/src/rhiza_tools/commands/suppression/__init__.py
+++ b/src/rhiza_tools/commands/suppression/__init__.py
@@ -1,0 +1,59 @@
+"""Suppression audit: scan the codebase for inline suppressions and grade them.
+
+Detects and reports on inline suppression comments such as:
+
+- ``# noqa`` / ``# noqa: CODE`` (ruff/flake8 linting suppressions)
+- ``# nosec`` / ``# nosec: CODE`` (bandit security suppressions)
+- ``# type: ignore`` / ``# type: ignore[CODE]`` (mypy/pyright type suppressions)
+- ``# pragma: no cover`` (coverage suppressions)
+- ``# noinspection CODE`` (PyCharm/IDE suppressions)
+
+Outputs a detailed per-file report, an ASCII histogram, and a letter grade.
+
+This package is the thin orchestrator. Parsing lives in
+:mod:`rhiza_tools.commands.suppression.parse` and reporting/output lives in
+:mod:`rhiza_tools.commands.suppression.report`.
+
+Example:
+    Run the audit over the working tree::
+
+        from rhiza_tools.commands.suppression import suppression_audit_command
+        suppression_audit_command(fail_stale_nosec_cve=False, pip_audit_args=[])
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rhiza_tools.commands.suppression.parse import collect_suppressions
+from rhiza_tools.commands.suppression.report import check_stale_nosec_cves, print_report
+
+__all__ = ["suppression_audit_command"]
+
+
+def suppression_audit_command(fail_stale_nosec_cve: bool, pip_audit_args: list[str]) -> int:
+    """Run the suppression audit and print a structured report.
+
+    Scans the working directory tree for inline suppression comments, prints a
+    per-file report, a histogram by code, and an overall density grade. When
+    ``fail_stale_nosec_cve`` is True it additionally cross-checks CVE-tagged
+    ``# nosec`` comments against live pip-audit findings and fails on stale ones.
+
+    Args:
+        fail_stale_nosec_cve: If True, fail when ``# nosec`` comments reference
+            CVEs that pip-audit no longer reports.
+        pip_audit_args: Extra arguments forwarded to pip-audit for the stale-CVE
+            gate.
+
+    Returns:
+        A process exit code: ``0`` on success, ``1`` when stale CVE-tagged
+        ``# nosec`` suppressions are found, or ``2`` when pip-audit fails to run.
+    """
+    root = Path(".")
+    py_files, all_suppressions, total_lines = collect_suppressions(root)
+    print_report(py_files, all_suppressions, total_lines)
+
+    if fail_stale_nosec_cve:
+        return check_stale_nosec_cves(all_suppressions, pip_audit_args)
+
+    return 0

--- a/src/rhiza_tools/commands/suppression/parse.py
+++ b/src/rhiza_tools/commands/suppression/parse.py
@@ -1,0 +1,247 @@
+"""Parsing layer for the suppression audit: scan source for inline suppressions.
+
+This module owns the *parsing* concerns of the suppression audit:
+
+- The suppression comment patterns (``# noqa``, ``# nosec``, ``# type: ignore``,
+  ``# pragma: no cover``, ``# noinspection``).
+- The :class:`Suppression` data model.
+- File scanning via Python's ``tokenize`` module so that only real comment
+  tokens are inspected.
+- Density grading and CVE extraction from ``# nosec`` comments.
+
+Rendering and process-exit logic live in :mod:`rhiza_tools.commands.suppression.report`;
+orchestration and the CLI live in :mod:`rhiza_tools.commands.suppression`.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import tokenize
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Suppression patterns
+# ---------------------------------------------------------------------------
+
+# Each entry: (kind_label, compiled_regex).
+# The first capture group (if any) captures the comma-separated rule codes.
+SUPPRESSION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "noqa",
+        re.compile(r"#\s*noqa(?:\s*:\s*([A-Z0-9]+(?:\s*,\s*[A-Z0-9]+)*))?", re.IGNORECASE),
+    ),
+    (
+        "nosec",
+        re.compile(r"#\s*nosec(?:\s*:?\s*([A-Z0-9]+(?:\s*,\s*[A-Z0-9]+)*))?", re.IGNORECASE),
+    ),
+    (
+        "type:ignore",
+        re.compile(r"#\s*type\s*:\s*ignore(?:\[([^\]]+)\])?", re.IGNORECASE),
+    ),
+    (
+        "no cover",
+        re.compile(r"#\s*pragma\s*:\s*no\s+cover", re.IGNORECASE),
+    ),
+    (
+        "noinspection",
+        re.compile(r"#\s*noinspection\s+(\w+)", re.IGNORECASE),
+    ),
+]
+
+# Directories to skip during the scan
+_SKIP_DIRS = {".venv", ".git", "node_modules", ".tox", "build", "dist", "__pycache__", "tests"}
+
+_CVE_RE = re.compile(r"\bCVE-\d{4}-\d+\b", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Suppression:
+    """A single suppression comment found in the codebase.
+
+    Attributes:
+        file: Path to the file containing the suppression.
+        line_no: 1-based line number of the comment.
+        kind: Suppression family label (e.g. ``"noqa"``, ``"nosec"``,
+            ``"type:ignore"``, ``"no cover"``, ``"noinspection"``).
+        codes: The specific rule codes named in the comment, if any
+            (e.g. ``["E501", "F401"]``); empty for blanket suppressions.
+        raw: The verbatim comment text, used for downstream CVE extraction.
+    """
+
+    file: str
+    line_no: int
+    kind: str
+    codes: list[str] = field(default_factory=list)
+    raw: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Scanning helpers
+# ---------------------------------------------------------------------------
+
+
+def _should_skip(path: Path) -> bool:
+    """Return True if any path component is in the skip-list."""
+    return bool(_SKIP_DIRS.intersection(path.parts))
+
+
+def _is_rhiza_repo(root: Path) -> bool:
+    """Return True if *root* is the rhiza framework repo itself.
+
+    Consumer repos have a ``.rhiza/template.yml`` file that records the upstream
+    rhiza repository reference. The rhiza repo itself never has this file — its
+    absence is the reliable signal that we are running inside the framework repo.
+    """
+    return not (root / ".rhiza" / "template.yml").exists()
+
+
+def scan_file(path: Path) -> list[Suppression]:
+    """Scan a single Python file and return all suppressions found.
+
+    Uses Python's ``tokenize`` module so that only actual comment tokens are
+    inspected — patterns that appear inside string literals or docstrings are
+    correctly ignored.
+
+    Args:
+        path: Path to the Python file to scan.
+
+    Returns:
+        A list of :class:`Suppression` records, one per matching comment line, in
+        source order. Empty if the file cannot be read or fails to tokenize.
+    """
+    suppressions: list[Suppression] = []
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return suppressions
+
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(source).readline)
+        for tok_type, tok_string, tok_start, _tok_end, _line in tokens:
+            if tok_type != tokenize.COMMENT:
+                continue
+            line_no = tok_start[0]
+            for kind, pattern in SUPPRESSION_PATTERNS:
+                match = pattern.search(tok_string)
+                if match:
+                    codes_raw = match.group(1) if match.lastindex and match.group(1) else ""
+                    codes = [c.strip() for c in codes_raw.split(",") if c.strip()] if codes_raw else []
+                    suppressions.append(
+                        Suppression(
+                            file=str(path),
+                            line_no=line_no,
+                            kind=kind,
+                            codes=codes,
+                            raw=tok_string.strip(),
+                        )
+                    )
+                    break  # count each comment line once
+    except (tokenize.TokenError, IndentationError):
+        pass  # skip files with tokenization errors or bad indentation
+
+    return suppressions
+
+
+def count_non_empty_lines(path: Path) -> int:
+    """Count non-empty lines in a file.
+
+    Args:
+        path: Path to the file to measure.
+
+    Returns:
+        The number of lines that contain non-whitespace characters, or ``0`` if
+        the file cannot be read. Used as the denominator for suppression density.
+    """
+    try:
+        return sum(1 for line in path.read_text(encoding="utf-8", errors="replace").splitlines() if line.strip())
+    except OSError:
+        return 0
+
+
+def collect_suppressions(root: Path) -> tuple[list[Path], list[Suppression], int]:
+    """Collect Python files, suppressions, and non-empty line counts.
+
+    Args:
+        root: Directory tree to scan recursively for Python files.
+
+    Returns:
+        A tuple ``(py_files, suppressions, total_lines)`` where ``py_files`` is
+        the sorted list of scanned files, ``suppressions`` aggregates every
+        :class:`Suppression` found, and ``total_lines`` is the combined count of
+        non-empty lines across those files.
+    """
+    in_rhiza_repo = _is_rhiza_repo(root)
+
+    def _include(p: Path) -> bool:
+        """Return True when a Python file should be scanned for suppressions."""
+        if _should_skip(p):
+            return False
+        # In consumer repos, skip the .rhiza/ framework directory entirely
+        return not (not in_rhiza_repo and ".rhiza" in p.parts)
+
+    py_files = sorted(p for p in root.rglob("*.py") if _include(p))
+
+    all_suppressions: list[Suppression] = []
+    total_lines = 0
+    for py_file in py_files:
+        all_suppressions.extend(scan_file(py_file))
+        total_lines += count_non_empty_lines(py_file)
+
+    return py_files, all_suppressions, total_lines
+
+
+def nosec_cves(suppressions: list[Suppression]) -> set[str]:
+    """Extract CVE identifiers referenced by # nosec suppressions.
+
+    Args:
+        suppressions: Suppression records to inspect.
+
+    Returns:
+        The set of upper-cased CVE identifiers found in the raw text of
+        ``# nosec`` comments. Non-``nosec`` suppressions are ignored.
+    """
+    cves: set[str] = set()
+    for sup in suppressions:
+        if sup.kind != "nosec":
+            continue
+        cves.update(match.upper() for match in _CVE_RE.findall(sup.raw))
+    return cves
+
+
+# ---------------------------------------------------------------------------
+# Grading
+# ---------------------------------------------------------------------------
+
+# Grade thresholds: suppressions per 100 lines of code
+_GRADE_THRESHOLDS: list[tuple[float, str]] = [
+    (0.0, "A+"),
+    (0.5, "A"),
+    (1.0, "B"),
+    (2.0, "C"),
+    (3.0, "D"),
+]
+
+
+def compute_grade(density: float) -> str:
+    """Return a letter grade based on suppression density.
+
+    Args:
+        density: Number of suppressions per 100 non-empty lines of code.
+
+    Returns:
+        A letter grade from ``"A+"`` (zero suppressions) down to ``"F"``,
+        derived from :data:`_GRADE_THRESHOLDS`.
+    """
+    grade = "F"
+    for threshold, letter in _GRADE_THRESHOLDS:
+        if density <= threshold:
+            grade = letter
+            break
+    return grade

--- a/src/rhiza_tools/commands/suppression/report.py
+++ b/src/rhiza_tools/commands/suppression/report.py
@@ -1,0 +1,207 @@
+"""Reporting layer for the suppression audit: render output and run pip-audit.
+
+This module owns the *reporting* and *output* concerns of the suppression audit:
+
+- ANSI colour constants and the ASCII histogram bar.
+- Printing the detailed per-file report, the histogram, and the density grade.
+- Cross-checking CVE-tagged ``# nosec`` comments against live pip-audit findings
+  (the ``--fail-stale-nosec-cve`` gate), including the subprocess invocation.
+
+The rendering uses ANSI-coloured ``print`` output rather than the shared
+``console`` helpers: this module emits a self-contained report (histogram,
+per-file listing, grade) whose layout and colour scheme are part of its
+contract. Parsing concerns live in :mod:`rhiza_tools.commands.suppression.parse`;
+orchestration and the CLI live in :mod:`rhiza_tools.commands.suppression`.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess  # nosec B404
+import sys
+from collections import Counter
+from pathlib import Path
+
+from rhiza_tools.commands.suppression.parse import Suppression, compute_grade, nosec_cves
+
+# ---------------------------------------------------------------------------
+# Rendering constants
+# ---------------------------------------------------------------------------
+
+_BAR_WIDTH = 24
+
+_GRADE_COLOURS = {
+    "A+": "\033[92m",  # bright green
+    "A": "\033[32m",  # green
+    "B": "\033[32m",  # green
+    "C": "\033[33m",  # yellow
+    "D": "\033[33m",  # yellow
+    "F": "\033[31m",  # red
+}
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_BLUE = "\033[36m"
+_YELLOW = "\033[33m"
+_GREEN = "\033[32m"
+_RED = "\033[31m"
+
+
+def _bar(count: int, max_count: int) -> str:
+    """Render a fixed-width ASCII progress bar."""
+    if max_count == 0:
+        return "░" * _BAR_WIDTH
+    filled = round(count / max_count * _BAR_WIDTH)
+    return "█" * filled + "░" * (_BAR_WIDTH - filled)
+
+
+# ---------------------------------------------------------------------------
+# Report rendering
+# ---------------------------------------------------------------------------
+
+
+def print_report(py_files: list[Path], all_suppressions: list[Suppression], total_lines: int) -> None:
+    """Print the suppression audit report.
+
+    Args:
+        py_files: The Python files that were scanned.
+        all_suppressions: Every suppression discovered across those files.
+        total_lines: Combined count of non-empty lines, used as the density
+            denominator.
+    """
+    # -----------------------------------------------------------------------
+    # Header
+    # -----------------------------------------------------------------------
+    print()
+    print(f"{_BOLD}{'=' * 62}{_RESET}")
+    print(f"{_BOLD}  Suppression Audit Report{_RESET}")
+    print(f"{_BOLD}{'=' * 62}{_RESET}")
+    print()
+
+    # -----------------------------------------------------------------------
+    # Detailed per-file report
+    # -----------------------------------------------------------------------
+    print(f"{_BOLD}Detailed Report:{_RESET}")
+    if all_suppressions:
+        for sup in all_suppressions:
+            codes_str = f"[{', '.join(sup.codes)}]" if sup.codes else ""
+            print(f"  {_YELLOW}{sup.file}{_RESET}:{_GREEN}{sup.line_no}{_RESET}: # {sup.kind}{codes_str}")
+    else:
+        print(f"  {_GREEN}No inline suppressions found.{_RESET}")
+    print()
+
+    # -----------------------------------------------------------------------
+    # Histogram by code
+    # -----------------------------------------------------------------------
+    print(f"{_BOLD}Histogram (by suppression code):{_RESET}")
+    code_counter: Counter[str] = Counter()
+    for sup in all_suppressions:
+        if sup.codes:
+            for code in sup.codes:
+                code_counter[f"{sup.kind}[{code}]"] += 1
+        else:
+            code_counter[f"{sup.kind}"] += 1
+    if code_counter:
+        max_code_count = max(code_counter.values())
+        total_code_count = sum(code_counter.values())
+        for label, count in code_counter.most_common():
+            pct = count / total_code_count * 100
+            print(f"  {label:<20} {_BLUE}{_bar(count, max_code_count)}{_RESET}  {count:>3}  ({pct:.0f}%)")
+    else:
+        print("  (none)")
+    print()
+
+    # -----------------------------------------------------------------------
+    # Summary + Grade
+    # -----------------------------------------------------------------------
+    density = (len(all_suppressions) / total_lines * 100) if total_lines > 0 else 0.0
+    grade = compute_grade(density)
+    grade_colour = _GRADE_COLOURS.get(grade, _RESET)
+
+    print(f"{_BOLD}Summary:{_RESET}")
+    print(f"  Files scanned   : {len(py_files)}")
+    print(f"  Lines scanned   : {total_lines:,}")
+    print(f"  Suppressions    : {len(all_suppressions)}")
+    print(f"  Density         : {density:.2f} per 100 lines")
+    print()
+    print(f"  Grade           : {grade_colour}{_BOLD}{grade}{_RESET}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Stale CVE gate
+# ---------------------------------------------------------------------------
+
+
+def _active_pip_audit_ids(extra_args: list[str]) -> set[str]:
+    """Return vulnerability IDs currently reported by pip-audit.
+
+    Args:
+        extra_args: Additional arguments forwarded verbatim to pip-audit.
+
+    Returns:
+        The set of upper-cased vulnerability IDs and aliases reported by
+        pip-audit for the current environment.
+
+    Raises:
+        RuntimeError: If pip-audit exits with an unexpected code or does not
+            return valid JSON.
+    """
+    uvx = shutil.which("uvx") or "uvx"
+    cmd = [uvx, "pip-audit", "--format", "json", *extra_args]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)  # nosec B603 - uvx/pip-audit is trusted  # noqa: S603
+
+    if proc.returncode not in {0, 1}:
+        sys.stdout.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+        raise RuntimeError("pip-audit execution failed")  # noqa: TRY003
+
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("pip-audit did not return valid JSON") from exc  # noqa: TRY003
+
+    ids: set[str] = set()
+    for dep in data.get("dependencies", []):
+        for vuln in dep.get("vulns", []):
+            vuln_id = vuln.get("id")
+            if vuln_id:
+                ids.add(str(vuln_id).upper())
+            for alias in vuln.get("aliases", []):
+                ids.add(str(alias).upper())
+    return ids
+
+
+def check_stale_nosec_cves(suppressions: list[Suppression], pip_audit_args: list[str]) -> int:
+    """Validate CVE-tagged # nosec suppressions against active pip-audit findings.
+
+    Args:
+        suppressions: Suppression records to inspect for CVE-tagged ``# nosec``
+            comments.
+        pip_audit_args: Extra arguments forwarded to ``pip-audit``.
+
+    Returns:
+        A process exit code: ``0`` when no stale CVE suppressions are found,
+        ``1`` when stale suppressions are detected, or ``2`` when pip-audit
+        fails to run.
+    """
+    suppressed_cves = nosec_cves(suppressions)
+    if not suppressed_cves:
+        print(f"{_GREEN}[OK]{_RESET} No CVE-tagged # nosec suppressions found.")
+        return 0
+
+    try:
+        active_cves = _active_pip_audit_ids(pip_audit_args)
+    except RuntimeError as exc:
+        print(f"{_RED}[FAIL]{_RESET} {exc}")
+        return 2
+
+    stale = sorted(cve for cve in suppressed_cves if cve not in active_cves)
+    if stale:
+        print(f"{_RED}[FAIL]{_RESET} Stale # nosec CVE suppressions detected:")
+        for cve in stale:
+            print(f"  - {cve}")
+        return 1
+
+    print(f"{_GREEN}[OK]{_RESET} All CVE-tagged # nosec suppressions match active pip-audit findings.")
+    return 0

--- a/tests/commands/suppression/test_suppression.py
+++ b/tests/commands/suppression/test_suppression.py
@@ -1,0 +1,311 @@
+"""Unit and CLI tests for the suppression-audit command and its modules."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+from rhiza_tools.cli import app
+from rhiza_tools.commands.suppression import parse, report, suppression_audit_command
+
+runner = CliRunner()
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI colour escape codes so output can be asserted on plainly."""
+    return _ANSI.sub("", text)
+
+
+# ---------------------------------------------------------------------------
+# CVE extraction and pip-audit parsing
+# ---------------------------------------------------------------------------
+
+
+def test_nosec_cves_extracts_only_nosec_entries():
+    """Only # nosec suppressions with CVE tags should be captured."""
+    suppressions = [
+        parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234"),
+        parse.Suppression(file="b.py", line_no=2, kind="noqa", raw="# noqa: E501 CVE-2024-0001"),
+        parse.Suppression(file="c.py", line_no=3, kind="nosec", raw="# nosec B602"),
+    ]
+    assert parse.nosec_cves(suppressions) == {"CVE-2024-1234"}
+
+
+def test_active_pip_audit_ids_collects_ids_and_aliases(monkeypatch):
+    """pip-audit JSON IDs and aliases should be normalized and returned."""
+    payload = """
+    {"dependencies": [{"name": "pkg", "vulns": [{"id": "PYSEC-1", "aliases": ["CVE-2024-1111"]}]}]}
+    """
+    monkeypatch.setattr(
+        report.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout=payload, stderr=""),
+    )
+    assert report._active_pip_audit_ids([]) == {"PYSEC-1", "CVE-2024-1111"}
+
+
+def test_active_pip_audit_ids_raises_on_unexpected_returncode(monkeypatch, capsys):
+    """A return code outside {0, 1} should surface a RuntimeError and echo output."""
+    monkeypatch.setattr(
+        report.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout="boom-out", stderr="boom-err"),
+    )
+    with pytest.raises(RuntimeError, match="pip-audit execution failed"):
+        report._active_pip_audit_ids([])
+    captured = capsys.readouterr()
+    assert "boom-out" in captured.out
+    assert "boom-err" in captured.err
+
+
+def test_active_pip_audit_ids_raises_on_invalid_json(monkeypatch):
+    """Non-JSON pip-audit output should raise a descriptive RuntimeError."""
+    monkeypatch.setattr(
+        report.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="not-json", stderr=""),
+    )
+    with pytest.raises(RuntimeError, match="did not return valid JSON"):
+        report._active_pip_audit_ids([])
+
+
+# ---------------------------------------------------------------------------
+# Scanning helpers
+# ---------------------------------------------------------------------------
+
+
+def test_should_skip_matches_skip_dirs():
+    """Paths inside a skip-listed directory should be skipped."""
+    assert parse._should_skip(Path(".venv") / "lib" / "mod.py") is True
+    assert parse._should_skip(Path("tests") / "test_mod.py") is True
+    assert parse._should_skip(Path("src") / "pkg" / "mod.py") is False
+
+
+def test_is_rhiza_repo_detects_template_marker(tmp_path):
+    """A project with .rhiza/template.yml is a consumer repo, otherwise the framework repo."""
+    assert parse._is_rhiza_repo(tmp_path) is True
+    (tmp_path / ".rhiza").mkdir()
+    (tmp_path / ".rhiza" / "template.yml").write_text("upstream: x\n", encoding="utf-8")
+    assert parse._is_rhiza_repo(tmp_path) is False
+
+
+def test_scan_file_detects_every_suppression_kind(tmp_path):
+    """scan_file should classify each suppression family and capture its codes."""
+    target = tmp_path / "sample.py"
+    target.write_text(
+        "\n".join(
+            [
+                "x = 1  # noqa: E501, F401",
+                "y = 2  # nosec B101",
+                "z: int = 3  # type: ignore[assignment]",
+                "w = 4  # pragma: no cover",
+                "v = 5  # noinspection PyUnresolvedReferences",
+                "ok = 6  # just a normal comment",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    found = {sup.kind: sup for sup in parse.scan_file(target)}
+    assert found["noqa"].codes == ["E501", "F401"]
+    assert found["nosec"].codes == ["B101"]
+    assert found["type:ignore"].codes == ["assignment"]
+    assert found["no cover"].codes == []
+    assert found["noinspection"].codes == ["PyUnresolvedReferences"]
+    assert "just a normal comment" not in {s.raw for s in parse.scan_file(target)}
+
+
+def test_scan_file_returns_empty_for_unreadable_file(tmp_path):
+    """A missing file should yield no suppressions rather than raising."""
+    assert parse.scan_file(tmp_path / "does-not-exist.py") == []
+
+
+def test_scan_file_swallows_tokenize_errors(tmp_path):
+    """A file that fails to tokenize should be skipped without raising."""
+    broken = tmp_path / "broken.py"
+    broken.write_text('x = "unterminated  # noqa: E501\n', encoding="utf-8")
+    assert isinstance(parse.scan_file(broken), list)
+
+
+def test_count_non_empty_lines(tmp_path):
+    """Only lines with non-whitespace content should be counted."""
+    target = tmp_path / "lines.py"
+    target.write_text("a = 1\n\n   \nb = 2\n", encoding="utf-8")
+    assert parse.count_non_empty_lines(target) == 2
+    assert parse.count_non_empty_lines(tmp_path / "missing.py") == 0
+
+
+# ---------------------------------------------------------------------------
+# Grading and rendering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("density", "expected"),
+    [(0.0, "A+"), (0.5, "A"), (1.0, "B"), (2.0, "C"), (3.0, "D"), (10.0, "F")],
+)
+def test_compute_grade_thresholds(density, expected):
+    """Grades should map to the documented density thresholds."""
+    assert parse.compute_grade(density) == expected
+
+
+def test_bar_renders_fixed_width():
+    """The histogram bar is always _BAR_WIDTH wide, all-empty when max is zero."""
+    assert report._bar(0, 0) == "░" * report._BAR_WIDTH
+    bar = report._bar(5, 10)
+    assert len(bar) == report._BAR_WIDTH
+    assert "█" in bar
+    assert "░" in bar
+
+
+# ---------------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------------
+
+
+def test_collect_suppressions_includes_rhiza_dir_in_framework_repo(tmp_path):
+    """In the framework repo (no template.yml) .rhiza/ files are scanned."""
+    (tmp_path / ".rhiza" / "utils").mkdir(parents=True)
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    (tmp_path / ".rhiza" / "utils" / "helper.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
+
+    py_files, suppressions, total_lines = parse.collect_suppressions(tmp_path)
+    scanned = {Path(s.file).name for s in suppressions}
+    assert scanned == {"app.py", "helper.py"}
+    assert total_lines == 2
+    assert len(py_files) == 2
+
+
+def test_collect_suppressions_skips_files_in_skip_dirs(tmp_path):
+    """Python files inside skip-listed directories (e.g. tests/) are excluded from the scan."""
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    (tmp_path / "tests" / "test_app.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
+
+    py_files, suppressions, _total = parse.collect_suppressions(tmp_path)
+    assert {Path(s.file).name for s in suppressions} == {"app.py"}
+    assert {p.name for p in py_files} == {"app.py"}
+
+
+def test_collect_suppressions_skips_rhiza_dir_in_consumer_repo(tmp_path):
+    """In a consumer repo (template.yml present) the .rhiza/ tree is excluded."""
+    (tmp_path / ".rhiza").mkdir()
+    (tmp_path / ".rhiza" / "template.yml").write_text("upstream: x\n", encoding="utf-8")
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    (tmp_path / ".rhiza" / "framework.py").write_text("b = 2  # nosec B101\n", encoding="utf-8")
+
+    _py_files, suppressions, _total = parse.collect_suppressions(tmp_path)
+    assert {Path(s.file).name for s in suppressions} == {"app.py"}
+
+
+def test_print_report_with_suppressions(capsys):
+    """The report should render details, a histogram, and a grade when suppressions exist."""
+    suppressions = [
+        parse.Suppression(file="app.py", line_no=10, kind="noqa", codes=["E501"], raw="# noqa: E501"),
+        parse.Suppression(file="app.py", line_no=20, kind="nosec", codes=[], raw="# nosec"),
+    ]
+    report.print_report([Path("app.py")], suppressions, total_lines=100)
+
+    out = _strip_ansi(capsys.readouterr().out)
+    assert "Suppression Audit Report" in out
+    assert "app.py:10: # noqa[E501]" in out
+    assert "Histogram (by suppression code):" in out
+    assert "noqa[E501]" in out
+    assert "Grade" in out
+    assert "Suppressions    : 2" in out
+
+
+def test_print_report_without_suppressions(capsys):
+    """A clean codebase should report no suppressions and an empty histogram."""
+    report.print_report([Path("app.py")], [], total_lines=0)
+    out = _strip_ansi(capsys.readouterr().out)
+    assert "No inline suppressions found." in out
+    assert "(none)" in out
+
+
+# ---------------------------------------------------------------------------
+# Stale-CVE gate
+# ---------------------------------------------------------------------------
+
+
+def test_check_stale_nosec_cves_no_suppressions(capsys):
+    """With no CVE-tagged # nosec comments the check passes without calling pip-audit."""
+    assert report.check_stale_nosec_cves([], []) == 0
+    assert "No CVE-tagged # nosec suppressions found." in _strip_ansi(capsys.readouterr().out)
+
+
+def test_check_stale_nosec_cves_flags_stale(monkeypatch, capsys):
+    """A suppressed CVE that pip-audit no longer reports is flagged as stale."""
+    suppressions = [parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    monkeypatch.setattr(report, "_active_pip_audit_ids", lambda _args: set())
+    assert report.check_stale_nosec_cves(suppressions, []) == 1
+    assert "Stale # nosec CVE suppressions detected:" in _strip_ansi(capsys.readouterr().out)
+
+
+def test_check_stale_nosec_cves_all_active(monkeypatch, capsys):
+    """A suppressed CVE that pip-audit still reports is considered current."""
+    suppressions = [parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    monkeypatch.setattr(report, "_active_pip_audit_ids", lambda _args: {"CVE-2024-1234"})
+    assert report.check_stale_nosec_cves(suppressions, []) == 0
+    assert "match active pip-audit findings." in _strip_ansi(capsys.readouterr().out)
+
+
+def test_check_stale_nosec_cves_pip_audit_failure(monkeypatch, capsys):
+    """A pip-audit RuntimeError should surface as exit code 2."""
+    suppressions = [parse.Suppression(file="a.py", line_no=1, kind="nosec", raw="# nosec B101 CVE-2024-1234")]
+    monkeypatch.setattr(
+        report.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout="", stderr=""),
+    )
+    assert report.check_stale_nosec_cves(suppressions, []) == 2
+    assert "pip-audit execution failed" in _strip_ansi(capsys.readouterr().out)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator + CLI
+# ---------------------------------------------------------------------------
+
+
+def test_command_reports_and_returns_zero(monkeypatch, tmp_path, capsys):
+    """A plain run scans the working tree, prints the report, and returns 0."""
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    assert suppression_audit_command(fail_stale_nosec_cve=False, pip_audit_args=[]) == 0
+    assert "Suppression Audit Report" in _strip_ansi(capsys.readouterr().out)
+
+
+def test_command_with_stale_gate_returns_one(monkeypatch, tmp_path, capsys):
+    """The stale-CVE gate fails when a suppressed CVE is no longer active."""
+    (tmp_path / "app.py").write_text("a = 1  # nosec B101 CVE-2024-9999\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(report, "_active_pip_audit_ids", lambda _args: set())
+
+    assert suppression_audit_command(fail_stale_nosec_cve=True, pip_audit_args=[]) == 1
+    assert "Stale # nosec CVE suppressions detected:" in _strip_ansi(capsys.readouterr().out)
+
+
+def test_cli_reports_and_exits_zero(monkeypatch, tmp_path):
+    """The CLI scans the working tree and exits 0 on a plain run."""
+    (tmp_path / "app.py").write_text("a = 1  # noqa: E501\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["suppression-audit"])
+    assert result.exit_code == 0
+    assert "Suppression Audit Report" in _strip_ansi(result.output)
+
+
+def test_cli_stale_gate_exits_one(monkeypatch, tmp_path):
+    """The CLI --fail-stale-nosec-cve flag maps a stale finding to exit code 1."""
+    (tmp_path / "app.py").write_text("a = 1  # nosec B101 CVE-2024-9999\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(report, "_active_pip_audit_ids", lambda _args: set())
+
+    result = runner.invoke(app, ["suppression-audit", "--fail-stale-nosec-cve"])
+    assert result.exit_code == 1

--- a/tests/commands/test_pip_audit.py
+++ b/tests/commands/test_pip_audit.py
@@ -1,0 +1,153 @@
+"""Unit and CLI tests for the pip-audit command."""
+
+from __future__ import annotations
+
+import json
+import re
+from types import SimpleNamespace
+
+from typer.testing import CliRunner
+
+from rhiza_tools.cli import app
+from rhiza_tools.commands import pip_audit
+
+runner = CliRunner()
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI colour escape codes so output can be asserted on plainly."""
+    return _ANSI.sub("", text)
+
+
+# ---------------------------------------------------------------------------
+# _vuln_ids
+# ---------------------------------------------------------------------------
+
+
+def test_vuln_ids_includes_primary_id_and_distinct_aliases():
+    """Vulnerability identifiers should include the primary ID and unique aliases."""
+    vuln = {"id": "PYSEC-2024-1", "aliases": ["CVE-2024-1234", "PYSEC-2024-1", "GHSA-xxxx-yyyy"]}
+    assert pip_audit._vuln_ids(vuln) == "PYSEC-2024-1, CVE-2024-1234, GHSA-xxxx-yyyy"
+
+
+# ---------------------------------------------------------------------------
+# pip_audit_command
+# ---------------------------------------------------------------------------
+
+
+def test_command_returns_zero_and_forwards_args_when_audit_passes(monkeypatch, capsys):
+    """A passing pip-audit run prints OK, returns zero, and forwards extra args."""
+    seen: dict[str, list[str]] = {}
+
+    def _fake_run(cmd, *, capture_output, text, check):
+        """Record the invoked command and return a passing (returncode 0) result."""
+        seen["cmd"] = cmd
+        assert capture_output is True
+        assert text is True
+        assert check is False
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pip_audit.shutil, "which", lambda name: "/custom/uvx")
+    monkeypatch.setattr(pip_audit.subprocess, "run", _fake_run)
+
+    assert pip_audit.pip_audit_command(["--ignore-vuln", "CVE-2024-1234"]) == 0
+    assert seen["cmd"] == ["/custom/uvx", "pip-audit", "--format", "json", "--ignore-vuln", "CVE-2024-1234"]
+    assert "[OK] pip-audit: no vulnerabilities found" in _strip_ansi(capsys.readouterr().out)
+
+
+def test_command_echoes_raw_output_when_json_parsing_fails(monkeypatch, capsys):
+    """Non-JSON output is passed through unchanged and preserves the exit code."""
+    monkeypatch.setattr(
+        pip_audit.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout="oops\n", stderr="bad\n"),
+    )
+
+    assert pip_audit.pip_audit_command([]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == "oops\n"
+    assert captured.err == "bad\n"
+
+
+def test_command_warns_for_tooling_vulnerabilities_without_failing(monkeypatch, capsys):
+    """Tooling-package vulnerabilities warn but still return success."""
+    payload = {
+        "dependencies": [
+            {"name": "pip", "version": "24.0", "vulns": [{"id": "PYSEC-2024-1", "aliases": ["CVE-2024-1234"]}]}
+        ]
+    }
+    monkeypatch.setattr(
+        pip_audit.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout=json.dumps(payload), stderr=""),
+    )
+
+    assert pip_audit.pip_audit_command([]) == 0
+    output = _strip_ansi(capsys.readouterr().out)
+    assert "[WARN] pip==24.0: PYSEC-2024-1, CVE-2024-1234 (tooling — not failing build)" in output
+    assert "[FAIL]" not in output
+
+
+def test_command_fails_for_runtime_vulnerabilities_and_warns_for_tooling(monkeypatch, capsys):
+    """Runtime-package vulnerabilities fail even when tooling warnings are present."""
+    payload = {
+        "dependencies": [
+            {"name": "setuptools", "version": "70.0", "vulns": [{"id": "PYSEC-2024-2", "aliases": []}]},
+            {"name": "requests", "version": "2.0.0", "vulns": [{"id": "GHSA-abcd", "aliases": ["CVE-2024-5678"]}]},
+        ]
+    }
+    monkeypatch.setattr(pip_audit.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        pip_audit.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout=json.dumps(payload), stderr=""),
+    )
+
+    assert pip_audit.pip_audit_command([]) == 1
+    output = _strip_ansi(capsys.readouterr().out)
+    assert "[WARN] setuptools==70.0: PYSEC-2024-2 (tooling — not failing build)" in output
+    assert "[FAIL] requests==2.0.0: GHSA-abcd, CVE-2024-5678" in output
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+
+def test_cli_forwards_extra_args_and_exits_zero(monkeypatch):
+    """The CLI forwards trailing args to pip-audit and maps a clean run to exit 0."""
+    seen: dict[str, list[str]] = {}
+
+    def _fake_run(cmd, **kwargs):
+        """Capture the command pip-audit would run and report a clean result."""
+        seen["cmd"] = cmd
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pip_audit.shutil, "which", lambda name: "uvx")
+    monkeypatch.setattr(pip_audit.subprocess, "run", _fake_run)
+
+    result = runner.invoke(app, ["pip-audit", "--ignore-vuln", "CVE-2024-1234"])
+    assert result.exit_code == 0
+    assert seen["cmd"] == ["uvx", "pip-audit", "--format", "json", "--ignore-vuln", "CVE-2024-1234"]
+
+
+def test_cli_exit_code_reflects_runtime_vulnerability(monkeypatch):
+    """A runtime vulnerability makes the CLI exit non-zero."""
+    payload = {"dependencies": [{"name": "requests", "version": "2.0.0", "vulns": [{"id": "GHSA-abcd"}]}]}
+    monkeypatch.setattr(
+        pip_audit.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout=json.dumps(payload), stderr=""),
+    )
+
+    result = runner.invoke(app, ["pip-audit"])
+    assert result.exit_code == 1
+
+
+def test_cli_help_lists_command():
+    """The pip-audit command exposes help text."""
+    result = runner.invoke(app, ["pip-audit", "--help"])
+    assert result.exit_code == 0
+    assert "pip-audit" in result.stdout


### PR DESCRIPTION
## What

Adds two audit commands to `rhiza-tools`, moving the utilities that are currently vendored into **every** consumer repo's `.rhiza/utils/`:

- **`pip-audit`** — runs `pip-audit` with a tiered vulnerability policy (runtime deps fail; build tooling `pip`/`setuptools`/`wheel`/`distribute` warn without failing). Trailing args are forwarded verbatim to `pip-audit`.
- **`suppression-audit`** — scans for inline suppressions (`# noqa`, `# nosec`, `# type: ignore`, `# pragma: no cover`, `# noinspection`), prints a per-file report + ASCII histogram + density grade, and offers the `--fail-stale-nosec-cve` gate that cross-checks CVE-tagged `# nosec` comments against live `pip-audit` findings.

Both are registered on the existing Typer `app`, so they are reachable as `rhiza-tools <cmd>` **and** `rhiza tools <cmd>` (via the unchanged `rhiza.plugins` entry point).

## Why

This is the `rhiza-tools` half of **jebel-quant/rhiza#1377** — leaning out the vendored `.rhiza/` footprint by relocating tooling into the already-published, already-pinned CLI family instead of shipping it as loose files in every repo.

## Layout

- `commands/pip_audit.py` — `pip_audit_command(extra_args)` (was `.rhiza/utils/pip_audit_policy.py:main`)
- `commands/suppression/` — `__init__.py` orchestrator + `parse.py` + `report.py` (was the three `.rhiza/utils/suppression_*.py` modules; cross-imports rewritten from path-hacks to package-relative)
- `cli.py` — two thin `@app.command` wrappers using `allow_extra_args`/`ignore_unknown_options` to forward flags to `pip-audit`

## Tests / gates (all green locally)

- Full suite: **493 passed**
- Ported the utilities' original unit tests (importlib path-loading → direct imports) + added CLI coverage
- `ruff check` / `ruff format --check`, `mypy --strict`, `ty` all clean
- README Commands section updated for both commands (the `test_doc_consistency` gate requires it)

## Follow-up (not in this PR)

Rewiring the **rhiza template repo**'s `make.d/{quality,test}.mk` to call `rhiza tools pip-audit` / `rhiza tools suppression-audit` instead of `uv run .rhiza/utils/*.py`, and dropping the vendored `.rhiza/utils/**`. Tracked in jebel-quant/rhiza#1377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)