### PR TITLE
refactor: cut command complexity and decouple the _shared hub (#313, #314)

### DIFF
--- a/src/rhiza_tools/commands/_git.py
+++ b/src/rhiza_tools/commands/_git.py
@@ -1,59 +1,19 @@
-"""Shared utilities for rhiza-tools commands.
+"""Git plumbing shared across rhiza-tools commands.
 
-This module provides common helpers used across multiple command modules
-(bump, release, rollback) to avoid duplication and ensure consistency.
+This module owns the git-facing helpers used by the bump, release, and rollback
+flows:
 
-Utilities:
-    - COOL_STYLE: Shared questionary styling for interactive prompts
-    - run_git_command: Execute git commands with standard error handling
-    - check_tag_exists: Report whether a tag exists locally and/or remotely
-    - get_current_version: Read the project version from pyproject.toml
-    - get_current_git_branch: Safely determine the current git branch
-    - get_latest_remote_version: Highest semver tag published on the remote
-    - validate_pyproject_exists: Guard against missing pyproject.toml
+    - run_git_command: Execute git commands with standard error handling.
+    - check_tag_exists: Report whether a tag exists locally and/or remotely.
+    - get_current_git_branch: Safely determine the current git branch.
+    - get_latest_remote_version: Highest semver tag published on the remote.
 """
 
 import subprocess  # nosec B404 - subprocess needed for git operations
-import tomllib
-from pathlib import Path
 
-import questionary as qs
 import semver
-import typer
 
 from rhiza_tools import console
-
-# The win32 import only succeeds on Windows, so exactly one platform exercises
-# each side of this branch; the fallback can never be covered on Windows.
-try:
-    from prompt_toolkit.output.win32 import (  # type: ignore[attr-defined]
-        NoConsoleScreenBufferError as _WinConsoleError,
-    )
-except (ImportError, AssertionError):  # pragma: no cover
-
-    class _WinConsoleError(Exception):  # type: ignore[no-redef]
-        """Sentinel: never raised outside of Windows environments."""
-
-
-# Tuple of exceptions indicating a non-interactive environment (no TTY).
-# Use this in except clauses instead of bare ``EOFError`` so that Windows CI
-# (which raises ``NoConsoleScreenBufferError`` instead of ``EOFError``) is
-# handled consistently.
-NON_INTERACTIVE_ERRORS: tuple[type[BaseException], ...] = (EOFError, _WinConsoleError)
-
-COOL_STYLE = qs.Style(
-    [
-        ("separator", "fg:#cc5454"),
-        ("qmark", "fg:#2FA4A9 bold"),
-        ("question", ""),
-        ("selected", "fg:#2FA4A9 bold"),
-        ("pointer", "fg:#2FA4A9 bold"),
-        ("highlighted", "fg:#2FA4A9 bold"),
-        ("answer", "fg:#2FA4A9 bold"),
-        ("text", "fg:#ffffff"),
-        ("disabled", "fg:#858585 italic"),
-    ]
-)
 
 
 def run_git_command(command: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -79,29 +39,6 @@ def run_git_command(command: list[str], check: bool = True) -> subprocess.Comple
         console.error(f"Error: {result.stderr}")
         raise subprocess.CalledProcessError(result.returncode, command, result.stdout, result.stderr)
     return result
-
-
-def get_current_version() -> str:
-    """Read current version from pyproject.toml.
-
-    Returns:
-        The current version string from the project.version field.
-
-    Raises:
-        typer.Exit: If pyproject.toml cannot be read or parsed.
-
-    Example:
-        >>> version = get_current_version()  # doctest: +SKIP
-        >>> print(version)  # doctest: +SKIP
-        0.1.0
-    """
-    try:
-        with open("pyproject.toml", "rb") as f:
-            data = tomllib.load(f)
-        return str(data["project"]["version"])
-    except (OSError, tomllib.TOMLDecodeError, KeyError, TypeError) as e:
-        console.error(f"Failed to read version from pyproject.toml: {e}")
-        raise typer.Exit(code=1) from None
 
 
 def check_tag_exists(tag: str) -> tuple[bool, bool]:
@@ -189,42 +126,3 @@ def get_latest_remote_version(remote: str = "origin") -> semver.Version | None:
             continue
 
     return max(versions) if versions else None
-
-
-def parse_semver_or_exit(version_str: str, *, strip_v_prefix: bool = False) -> semver.Version:
-    """Parse a semantic version string, exiting with a consistent error on failure.
-
-    Centralises the parse-and-exit pattern that several commands previously
-    duplicated, so an unparseable version is always reported the same way.
-
-    Args:
-        version_str: The version to parse (e.g. ``"1.2.3"`` or ``"v1.2.3"``).
-        strip_v_prefix: If True, drop a leading ``"v"`` before parsing.
-
-    Returns:
-        The parsed :class:`semver.Version`.
-
-    Raises:
-        typer.Exit: If ``version_str`` is not a valid semantic version.
-
-    Example:
-        >>> parse_semver_or_exit("1.2.3")  # doctest: +SKIP
-        Version(major=1, minor=2, patch=3, ...)
-    """
-    candidate = version_str[1:] if strip_v_prefix and version_str.startswith("v") else version_str
-    try:
-        return semver.Version.parse(candidate)
-    except ValueError:
-        console.error(f"Invalid semantic version: {version_str}")
-        raise typer.Exit(code=1) from None
-
-
-def validate_pyproject_exists() -> None:
-    """Validate that pyproject.toml exists in the current directory.
-
-    Raises:
-        typer.Exit: If pyproject.toml is not found.
-    """
-    if not Path("pyproject.toml").exists():
-        console.error("pyproject.toml not found in current directory")
-        raise typer.Exit(code=1)

--- a/src/rhiza_tools/commands/_project.py
+++ b/src/rhiza_tools/commands/_project.py
@@ -1,0 +1,79 @@
+"""Project-metadata and version helpers shared across rhiza-tools commands.
+
+This module owns the ``pyproject.toml``-facing and semver-parsing helpers used
+by the bump, release, and rollback flows:
+
+    - get_current_version: Read the project version from pyproject.toml.
+    - parse_semver_or_exit: Parse a semver string, exiting consistently on error.
+    - validate_pyproject_exists: Guard against a missing pyproject.toml.
+"""
+
+import tomllib
+from pathlib import Path
+
+import semver
+import typer
+
+from rhiza_tools import console
+
+
+def get_current_version() -> str:
+    """Read current version from pyproject.toml.
+
+    Returns:
+        The current version string from the project.version field.
+
+    Raises:
+        typer.Exit: If pyproject.toml cannot be read or parsed.
+
+    Example:
+        >>> version = get_current_version()  # doctest: +SKIP
+        >>> print(version)  # doctest: +SKIP
+        0.1.0
+    """
+    try:
+        with open("pyproject.toml", "rb") as f:
+            data = tomllib.load(f)
+        return str(data["project"]["version"])
+    except (OSError, tomllib.TOMLDecodeError, KeyError, TypeError) as e:
+        console.error(f"Failed to read version from pyproject.toml: {e}")
+        raise typer.Exit(code=1) from None
+
+
+def parse_semver_or_exit(version_str: str, *, strip_v_prefix: bool = False) -> semver.Version:
+    """Parse a semantic version string, exiting with a consistent error on failure.
+
+    Centralises the parse-and-exit pattern that several commands previously
+    duplicated, so an unparseable version is always reported the same way.
+
+    Args:
+        version_str: The version to parse (e.g. ``"1.2.3"`` or ``"v1.2.3"``).
+        strip_v_prefix: If True, drop a leading ``"v"`` before parsing.
+
+    Returns:
+        The parsed :class:`semver.Version`.
+
+    Raises:
+        typer.Exit: If ``version_str`` is not a valid semantic version.
+
+    Example:
+        >>> parse_semver_or_exit("1.2.3")  # doctest: +SKIP
+        Version(major=1, minor=2, patch=3, ...)
+    """
+    candidate = version_str[1:] if strip_v_prefix and version_str.startswith("v") else version_str
+    try:
+        return semver.Version.parse(candidate)
+    except ValueError:
+        console.error(f"Invalid semantic version: {version_str}")
+        raise typer.Exit(code=1) from None
+
+
+def validate_pyproject_exists() -> None:
+    """Validate that pyproject.toml exists in the current directory.
+
+    Raises:
+        typer.Exit: If pyproject.toml is not found.
+    """
+    if not Path("pyproject.toml").exists():
+        console.error("pyproject.toml not found in current directory")
+        raise typer.Exit(code=1)

--- a/src/rhiza_tools/commands/_prompts.py
+++ b/src/rhiza_tools/commands/_prompts.py
@@ -1,0 +1,43 @@
+"""Interactive-prompt styling and non-interactive detection.
+
+This module owns the presentation concerns shared by the interactive command
+flows (bump, release, rollback):
+
+    - COOL_STYLE: Shared questionary styling for interactive prompts.
+    - NON_INTERACTIVE_ERRORS: Exceptions signalling a missing TTY, so callers can
+      degrade gracefully in CI.
+"""
+
+import questionary as qs
+
+# The win32 import only succeeds on Windows, so exactly one platform exercises
+# each side of this branch; the fallback can never be covered on Windows.
+try:
+    from prompt_toolkit.output.win32 import (  # type: ignore[attr-defined]
+        NoConsoleScreenBufferError as _WinConsoleError,
+    )
+except (ImportError, AssertionError):  # pragma: no cover
+
+    class _WinConsoleError(Exception):  # type: ignore[no-redef]
+        """Sentinel: never raised outside of Windows environments."""
+
+
+# Tuple of exceptions indicating a non-interactive environment (no TTY).
+# Use this in except clauses instead of bare ``EOFError`` so that Windows CI
+# (which raises ``NoConsoleScreenBufferError`` instead of ``EOFError``) is
+# handled consistently.
+NON_INTERACTIVE_ERRORS: tuple[type[BaseException], ...] = (EOFError, _WinConsoleError)
+
+COOL_STYLE = qs.Style(
+    [
+        ("separator", "fg:#cc5454"),
+        ("qmark", "fg:#2FA4A9 bold"),
+        ("question", ""),
+        ("selected", "fg:#2FA4A9 bold"),
+        ("pointer", "fg:#2FA4A9 bold"),
+        ("highlighted", "fg:#2FA4A9 bold"),
+        ("answer", "fg:#2FA4A9 bold"),
+        ("text", "fg:#ffffff"),
+        ("disabled", "fg:#858585 italic"),
+    ]
+)

--- a/src/rhiza_tools/commands/bump/__init__.py
+++ b/src/rhiza_tools/commands/bump/__init__.py
@@ -25,7 +25,7 @@ import semver
 import typer
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import (
+from rhiza_tools.commands._git import (
     get_current_git_branch,
     get_latest_remote_version,
 )

--- a/src/rhiza_tools/commands/bump/git.py
+++ b/src/rhiza_tools/commands/bump/git.py
@@ -17,10 +17,12 @@ import typer
 from loguru import logger
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import (
+from rhiza_tools.commands._git import (
+    run_git_command,
+)
+from rhiza_tools.commands._prompts import (
     COOL_STYLE,
     NON_INTERACTIVE_ERRORS,
-    run_git_command,
 )
 
 

--- a/src/rhiza_tools/commands/bump/io.py
+++ b/src/rhiza_tools/commands/bump/io.py
@@ -23,10 +23,12 @@ import typer
 from loguru import logger
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import (
+from rhiza_tools.commands._project import (
+    parse_semver_or_exit,
+)
+from rhiza_tools.commands._prompts import (
     COOL_STYLE,
     NON_INTERACTIVE_ERRORS,
-    parse_semver_or_exit,
 )
 from rhiza_tools.commands.bump.engine import BumpConfig, _get_files_to_modify
 from rhiza_tools.commands.bump.versioning import (

--- a/src/rhiza_tools/commands/bump/versioning.py
+++ b/src/rhiza_tools/commands/bump/versioning.py
@@ -13,7 +13,7 @@ import semver
 import typer
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import parse_semver_or_exit
+from rhiza_tools.commands._project import parse_semver_or_exit
 
 
 def _denormalize_pep440_to_semver(version_str: str) -> str:

--- a/src/rhiza_tools/commands/pip_audit.py
+++ b/src/rhiza_tools/commands/pip_audit.py
@@ -40,6 +40,52 @@ def _vuln_ids(vuln: dict) -> str:  # type: ignore[type-arg]
     return ", ".join(ids)
 
 
+def _run_pip_audit(extra_args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Invoke ``uvx pip-audit`` with JSON output, forwarding ``extra_args``.
+
+    Args:
+        extra_args: Additional arguments forwarded verbatim to pip-audit.
+
+    Returns:
+        The completed process, with ``stdout`` carrying pip-audit's JSON report.
+    """
+    uvx = shutil.which("uvx") or "uvx"
+    cmd = [uvx, "pip-audit", "--format", "json", *extra_args]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False)  # nosec B603 - uvx/pip-audit is trusted  # noqa: S603
+
+
+def _partition_vulns(deps: list[dict]) -> tuple[list[dict], list[dict]]:  # type: ignore[type-arg]
+    """Split vulnerable dependencies into (tooling, runtime) buckets.
+
+    Args:
+        deps: The ``dependencies`` array from pip-audit's JSON output.
+
+    Returns:
+        A tuple ``(tooling_vulns, runtime_vulns)`` of the dependencies that carry
+        vulnerabilities, classified by whether their name is in :data:`_TOOLING`.
+    """
+    vulnerable = [d for d in deps if d.get("vulns")]
+    tooling = [d for d in vulnerable if d["name"].lower() in _TOOLING]
+    runtime = [d for d in vulnerable if d["name"].lower() not in _TOOLING]
+    return tooling, runtime
+
+
+def _report_tooling(tooling_vulns: list[dict]) -> None:  # type: ignore[type-arg]
+    """Print a yellow WARN line for each vulnerability in build tooling."""
+    for dep in tooling_vulns:
+        for v in dep["vulns"]:
+            print(
+                f"{_YELLOW}[WARN] {dep['name']}=={dep['version']}: {_vuln_ids(v)} (tooling — not failing build){_RESET}"
+            )
+
+
+def _report_runtime(runtime_vulns: list[dict]) -> None:  # type: ignore[type-arg]
+    """Print a red FAIL line for each vulnerability in a runtime dependency."""
+    for dep in runtime_vulns:
+        for v in dep["vulns"]:
+            print(f"{_RED}[FAIL] {dep['name']}=={dep['version']}: {_vuln_ids(v)}{_RESET}")
+
+
 def pip_audit_command(extra_args: list[str]) -> int:
     """Run pip-audit and apply the tiered vulnerability policy.
 
@@ -63,9 +109,7 @@ def pip_audit_command(extra_args: list[str]) -> int:
 
             pip_audit_command(["--ignore-vuln", "CVE-2024-1234"])
     """
-    uvx = shutil.which("uvx") or "uvx"
-    cmd = [uvx, "pip-audit", "--format", "json", *extra_args]
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)  # nosec B603 - uvx/pip-audit is trusted  # noqa: S603
+    proc = _run_pip_audit(extra_args)
 
     if proc.returncode == 0:
         print(f"{_GREEN}[OK] pip-audit: no vulnerabilities found{_RESET}")
@@ -78,20 +122,11 @@ def pip_audit_command(extra_args: list[str]) -> int:
         sys.stderr.write(proc.stderr)
         return proc.returncode
 
-    deps = data.get("dependencies", [])
-    tooling_vulns = [d for d in deps if d.get("vulns") and d["name"].lower() in _TOOLING]
-    runtime_vulns = [d for d in deps if d.get("vulns") and d["name"].lower() not in _TOOLING]
-
-    for dep in tooling_vulns:
-        for v in dep["vulns"]:
-            print(
-                f"{_YELLOW}[WARN] {dep['name']}=={dep['version']}: {_vuln_ids(v)} (tooling — not failing build){_RESET}"
-            )
+    tooling_vulns, runtime_vulns = _partition_vulns(data.get("dependencies", []))
+    _report_tooling(tooling_vulns)
 
     if not runtime_vulns:
         return 0
 
-    for dep in runtime_vulns:
-        for v in dep["vulns"]:
-            print(f"{_RED}[FAIL] {dep['name']}=={dep['version']}: {_vuln_ids(v)}{_RESET}")
+    _report_runtime(runtime_vulns)
     return 1

--- a/src/rhiza_tools/commands/release/__init__.py
+++ b/src/rhiza_tools/commands/release/__init__.py
@@ -27,12 +27,14 @@ from pathlib import Path
 import typer
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import (
+from rhiza_tools.commands._git import (
     get_latest_remote_version,
-    parse_semver_or_exit,
 )
-from rhiza_tools.commands._shared import (
+from rhiza_tools.commands._git import (
     run_git_command as run_git_command,
+)
+from rhiza_tools.commands._project import (
+    parse_semver_or_exit,
 )
 from rhiza_tools.commands.bump import (
     Language,

--- a/src/rhiza_tools/commands/release/git.py
+++ b/src/rhiza_tools/commands/release/git.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 import typer
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import check_tag_exists as check_tag_exists
-from rhiza_tools.commands._shared import run_git_command
+from rhiza_tools.commands._git import check_tag_exists as check_tag_exists
+from rhiza_tools.commands._git import run_git_command
 
 # Number of fields in the `%H|%ci|%s` git-show format (commit hash, date, subject).
 _TAG_DETAIL_FIELDS = 3

--- a/src/rhiza_tools/commands/release/versioning.py
+++ b/src/rhiza_tools/commands/release/versioning.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import typer
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import parse_semver_or_exit
+from rhiza_tools.commands._project import parse_semver_or_exit
 from rhiza_tools.commands.bump import (
     BumpOptions,
     Language,

--- a/src/rhiza_tools/commands/rollback/__init__.py
+++ b/src/rhiza_tools/commands/rollback/__init__.py
@@ -28,12 +28,16 @@ import typer
 from loguru import logger
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import (
-    COOL_STYLE,
-    NON_INTERACTIVE_ERRORS,
+from rhiza_tools.commands._git import (
     check_tag_exists,
     run_git_command,
+)
+from rhiza_tools.commands._project import (
     validate_pyproject_exists,
+)
+from rhiza_tools.commands._prompts import (
+    COOL_STYLE,
+    NON_INTERACTIVE_ERRORS,
 )
 
 # Git tag/commit plumbing lives in rollback/git.py; re-exported here so callers and

--- a/src/rhiza_tools/commands/rollback/git.py
+++ b/src/rhiza_tools/commands/rollback/git.py
@@ -9,7 +9,7 @@ and UI in ``rollback.py``, which re-exports them for its callers and tests.
 from __future__ import annotations
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import run_git_command
+from rhiza_tools.commands._git import run_git_command
 
 # Number of fields in the `%H|%ci|%s` git-show format (commit hash, date, subject).
 _TAG_DETAIL_FIELDS = 3

--- a/src/rhiza_tools/commands/rollback/io.py
+++ b/src/rhiza_tools/commands/rollback/io.py
@@ -16,11 +16,13 @@ import typer
 from loguru import logger
 
 from rhiza_tools import console
-from rhiza_tools.commands._shared import (
-    COOL_STYLE,
-    NON_INTERACTIVE_ERRORS,
+from rhiza_tools.commands._git import (
     check_tag_exists,
     run_git_command,
+)
+from rhiza_tools.commands._prompts import (
+    COOL_STYLE,
+    NON_INTERACTIVE_ERRORS,
 )
 
 

--- a/src/rhiza_tools/commands/suppression/parse.py
+++ b/src/rhiza_tools/commands/suppression/parse.py
@@ -102,6 +102,28 @@ def _is_rhiza_repo(root: Path) -> bool:
     return not (root / ".rhiza" / "template.yml").exists()
 
 
+def _match_suppression(tok_string: str, line_no: int, path: Path) -> Suppression | None:
+    """Match a single comment token against the suppression patterns.
+
+    Args:
+        tok_string: The verbatim comment token text.
+        line_no: 1-based line number of the comment.
+        path: Path to the file the comment came from.
+
+    Returns:
+        A :class:`Suppression` for the first matching pattern, or ``None`` if the
+        comment is not a recognised suppression.
+    """
+    for kind, pattern in SUPPRESSION_PATTERNS:
+        match = pattern.search(tok_string)
+        if not match:
+            continue
+        codes_raw = match.group(1) if match.lastindex and match.group(1) else ""
+        codes = [c.strip() for c in codes_raw.split(",") if c.strip()] if codes_raw else []
+        return Suppression(file=str(path), line_no=line_no, kind=kind, codes=codes, raw=tok_string.strip())
+    return None
+
+
 def scan_file(path: Path) -> list[Suppression]:
     """Scan a single Python file and return all suppressions found.
 
@@ -127,22 +149,9 @@ def scan_file(path: Path) -> list[Suppression]:
         for tok_type, tok_string, tok_start, _tok_end, _line in tokens:
             if tok_type != tokenize.COMMENT:
                 continue
-            line_no = tok_start[0]
-            for kind, pattern in SUPPRESSION_PATTERNS:
-                match = pattern.search(tok_string)
-                if match:
-                    codes_raw = match.group(1) if match.lastindex and match.group(1) else ""
-                    codes = [c.strip() for c in codes_raw.split(",") if c.strip()] if codes_raw else []
-                    suppressions.append(
-                        Suppression(
-                            file=str(path),
-                            line_no=line_no,
-                            kind=kind,
-                            codes=codes,
-                            raw=tok_string.strip(),
-                        )
-                    )
-                    break  # count each comment line once
+            suppression = _match_suppression(tok_string, tok_start[0], path)
+            if suppression is not None:
+                suppressions.append(suppression)
     except (tokenize.TokenError, IndentationError):
         pass  # skip files with tokenization errors or bad indentation
 

--- a/tests/commands/release/test_release_command.py
+++ b/tests/commands/release/test_release_command.py
@@ -223,7 +223,7 @@ def test_check_tag_exists():
             result.returncode = 1  # doesn't exist remotely
         return result
 
-    with patch("rhiza_tools.commands._shared.run_git_command", side_effect=mock_run_git_command):
+    with patch("rhiza_tools.commands._git.run_git_command", side_effect=mock_run_git_command):
         local, remote = check_tag_exists("v1.0.0")
         assert local is True
         assert remote is False
@@ -561,7 +561,7 @@ def test_release_command_user_declines_push(mock_pyproject, monkeypatch):
 
     with (
         patch("rhiza_tools.commands.release.git.run_git_command", side_effect=mock_run_git_command),
-        patch("rhiza_tools.commands._shared.run_git_command", side_effect=mock_run_git_command),
+        patch("rhiza_tools.commands._git.run_git_command", side_effect=mock_run_git_command),
         patch("typer.confirm", return_value=False),
         patch("rhiza_tools.commands.release.versioning.bump_command"),
         patch("rhiza_tools.commands.release.versioning.get_interactive_bump_type", return_value="1.2.3"),
@@ -604,7 +604,7 @@ def test_release_command_success_non_dry_run(mock_pyproject, monkeypatch):
 
     with (
         patch("rhiza_tools.commands.release.git.run_git_command", side_effect=mock_run_git_command),
-        patch("rhiza_tools.commands._shared.run_git_command", side_effect=mock_run_git_command),
+        patch("rhiza_tools.commands._git.run_git_command", side_effect=mock_run_git_command),
         patch("rhiza_tools.commands.release.versioning.bump_command"),
     ):
         # Should complete successfully in non-interactive mode
@@ -638,7 +638,7 @@ def test_release_command_user_declines_non_default_branch(mock_pyproject, monkey
 
     with (
         patch("rhiza_tools.commands.release.git.run_git_command", side_effect=mock_run_git_command),
-        patch("rhiza_tools.commands._shared.run_git_command", side_effect=mock_run_git_command),
+        patch("rhiza_tools.commands._git.run_git_command", side_effect=mock_run_git_command),
         patch("typer.confirm", return_value=False),
         patch("rhiza_tools.commands.release.versioning.bump_command"),
         patch("rhiza_tools.commands.release.versioning.get_interactive_bump_type", return_value="1.2.3"),
@@ -743,7 +743,7 @@ def test_release_with_push_flag(mock_pyproject, monkeypatch):
 
     with (
         patch("rhiza_tools.commands.release.git.run_git_command", side_effect=mock_run_git_command),
-        patch("rhiza_tools.commands._shared.run_git_command", side_effect=mock_run_git_command),
+        patch("rhiza_tools.commands._git.run_git_command", side_effect=mock_run_git_command),
         patch("rhiza_tools.commands.release.git.push_tag", side_effect=mock_push_tag),
         patch("rhiza_tools.commands.release.versioning.bump_command"),
         patch("rhiza_tools.commands.release.versioning.get_interactive_bump_type", return_value="1.2.3"),
@@ -782,7 +782,7 @@ def test_release_non_interactive_with_bump(mock_pyproject, monkeypatch):
 
     with (
         patch("rhiza_tools.commands.release.git.run_git_command", side_effect=mock_git),
-        patch("rhiza_tools.commands._shared.run_git_command", side_effect=mock_git),
+        patch("rhiza_tools.commands._git.run_git_command", side_effect=mock_git),
         patch("rhiza_tools.commands.release.versioning.bump_command", side_effect=mock_bump_command),
     ):
         release_command(bump_type="MINOR", push=True, non_interactive=True)
@@ -905,7 +905,7 @@ def test_release_with_bump_push_checks_branch_before_pushing_commit(mock_pyproje
 
     with (
         patch("rhiza_tools.commands.release.git.run_git_command", side_effect=mock_git),
-        patch("rhiza_tools.commands._shared.run_git_command", side_effect=mock_git),
+        patch("rhiza_tools.commands._git.run_git_command", side_effect=mock_git),
         patch("rhiza_tools.commands.release.versioning.bump_command", side_effect=mock_bump_command),
     ):
         release_command(bump_type="PATCH", push=True, non_interactive=True)
@@ -1226,7 +1226,7 @@ class TestReleasePreflightValidation:
 
         with (
             patch("rhiza_tools.commands.release.git.run_git_command", side_effect=mock_run_git_command),
-            patch("rhiza_tools.commands._shared.run_git_command", side_effect=mock_run_git_command),
+            patch("rhiza_tools.commands._git.run_git_command", side_effect=mock_run_git_command),
             patch("rhiza_tools.commands.release.versioning.bump_command", side_effect=mock_bump_command),
             pytest.raises(typer.Exit),
         ):
@@ -1266,7 +1266,7 @@ class TestReleasePreflightValidation:
 
         with (
             patch("rhiza_tools.commands.release.git.run_git_command", side_effect=mock_run_git_command),
-            patch("rhiza_tools.commands._shared.run_git_command", side_effect=mock_run_git_command),
+            patch("rhiza_tools.commands._git.run_git_command", side_effect=mock_run_git_command),
             patch("rhiza_tools.commands.release.versioning.bump_command", side_effect=mock_bump_command),
             pytest.raises(typer.Exit),
         ):
@@ -1310,7 +1310,7 @@ class TestReleasePreflightValidation:
 
         with (
             patch("rhiza_tools.commands.release.git.run_git_command", side_effect=mock_git),
-            patch("rhiza_tools.commands._shared.run_git_command", side_effect=mock_git),
+            patch("rhiza_tools.commands._git.run_git_command", side_effect=mock_git),
             patch("rhiza_tools.commands.release.versioning.bump_command", side_effect=mock_bump_command),
         ):
             release_command(bump_type="PATCH", push=True, non_interactive=True)

--- a/tests/commands/test_project.py
+++ b/tests/commands/test_project.py
@@ -1,25 +1,25 @@
-"""Tests for rhiza_tools.commands._shared."""
+"""Tests for rhiza_tools.commands._project."""
 
 import pytest
 import typer
 
 
-class TestShared:
-    """Tests for uncovered branches in commands/_shared.py."""
+class TestProject:
+    """Tests for uncovered branches in commands/_project.py."""
 
     def test_get_current_version_success(self, tmp_path, monkeypatch):
-        """_shared.py:81-82 – returns version string from valid pyproject.toml."""
+        """get_current_version returns the version string from a valid pyproject.toml."""
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'\nversion = '1.2.3'\n")
-        from rhiza_tools.commands._shared import get_current_version
+        from rhiza_tools.commands._project import get_current_version
 
         assert get_current_version() == "1.2.3"
 
     def test_get_current_version_exception(self, tmp_path, monkeypatch):
-        """_shared.py:83-85 – exits when pyproject.toml cannot be parsed."""
+        """get_current_version exits when pyproject.toml cannot be parsed."""
         monkeypatch.chdir(tmp_path)
         (tmp_path / "pyproject.toml").write_text("[invalid toml [[[")
-        from rhiza_tools.commands._shared import get_current_version
+        from rhiza_tools.commands._project import get_current_version
 
         with pytest.raises(typer.Exit):
             get_current_version()

--- a/tests/test_versioning_guard_1126.py
+++ b/tests/test_versioning_guard_1126.py
@@ -18,7 +18,7 @@ import typer
 
 from rhiza_tools.commands import bump as bump_mod
 from rhiza_tools.commands import release as release_mod
-from rhiza_tools.commands._shared import get_latest_remote_version
+from rhiza_tools.commands._git import get_latest_remote_version
 from rhiza_tools.commands.bump import BumpOptions, Language, _resolve_bump_baseline, bump_command, get_current_version
 
 _BUMPVERSION_CFG = """
@@ -60,7 +60,7 @@ def _ls_remote(*tags: str) -> MagicMock:
 def test_latest_remote_version_picks_highest():
     """The highest semver tag wins, regardless of listing order."""
     with patch(
-        "rhiza_tools.commands._shared.run_git_command",
+        "rhiza_tools.commands._git.run_git_command",
         return_value=_ls_remote("v0.3.2", "v0.10.0", "v0.4.0"),
     ):
         assert get_latest_remote_version() == semver.Version.parse("0.10.0")
@@ -77,7 +77,7 @@ def test_latest_remote_version_ignores_non_semver_and_peeled_refs():
             "sha\trefs/heads/main\n"  # not a tag at all
         ),
     )
-    with patch("rhiza_tools.commands._shared.run_git_command", return_value=listing):
+    with patch("rhiza_tools.commands._git.run_git_command", return_value=listing):
         assert get_latest_remote_version() == semver.Version.parse("1.0.0")
 
 
@@ -90,7 +90,7 @@ def test_latest_remote_version_ignores_non_semver_and_peeled_refs():
 )
 def test_latest_remote_version_returns_none_when_unavailable(result):
     """Degrade gracefully to None when the remote can't be read or has no tags."""
-    with patch("rhiza_tools.commands._shared.run_git_command", return_value=result):
+    with patch("rhiza_tools.commands._git.run_git_command", return_value=result):
         assert get_latest_remote_version() is None
 
 


### PR DESCRIPTION
Addresses #313 and #314 — both surfaced by the rhiza v1.1.1 boost quality scorecard (PR #312).

## #313 — Reduce cyclomatic complexity below CC 11

| Function | Before | After |
|---|---|---|
| `pip_audit.py::pip_audit_command` | C (15) | **A (4)** |
| `suppression/parse.py::scan_file` | C (12) | **B (6)** |

- **`pip_audit_command`** — extracted `_run_pip_audit` (subprocess invocation), `_partition_vulns` (tooling/runtime split), and `_report_tooling` / `_report_runtime` (the nested print loops). The command body is now a linear policy flow.
- **`scan_file`** — extracted `_match_suppression`, which owns the pattern loop and code-parsing ternaries.

`uvx radon cc src -s -n C` prints **no blocks**.

## #314 — Lower coupling on the `_shared` utility hub

Deleted the 230-LOC `_shared.py` and split it by concern into three single-purpose modules. All three sit at the bottom layer (they import only `console` + third-party libs, no `commands/*`), so layering direction and the absence of import cycles are preserved.

| Module | Contents | Importers |
|---|---|---|
| `_git.py` | `run_git_command`, `check_tag_exists`, `get_current_git_branch`, `get_latest_remote_version` | 7 |
| `_project.py` | `get_current_version`, `parse_semver_or_exit`, `validate_pyproject_exists` | 5 |
| `_prompts.py` | `COOL_STYLE`, `NON_INTERACTIVE_ERRORS` | 4 |

Each command now imports only the concern it needs (e.g. `bump/git.py` pulls `_git` + `_prompts`, not the semver/pyproject helpers). No single utility module remains a cross-cutting import magnet.

## Verification
- `pytest`: **493 passed**, **100% coverage** (all new modules at 100%)
- `ruff check` + `ruff format --check`: clean
- `make typecheck` (ty + mypy --strict): clean
- `radon cc -n C`: no C-grade blocks

Closes #313
Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)