### PR TITLE
docs: decouple rhiza-tools from rhiza-cli

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ generation. Its own development infrastructure is synced from Rhiza.
 ## Rhiza-managed files — do NOT edit directly
 
 This project syncs its development infrastructure from the **Rhiza** template repo
-(`jebel-quant/rhiza`) via `rhiza-cli`. The configuration lives in
+(`jebel-quant/rhiza`). The configuration lives in
 [`.rhiza/template.yml`](.rhiza/template.yml) (profile `github-project` + the `legal`
 template).
 

--- a/README.md
+++ b/README.md
@@ -9,39 +9,21 @@
 
 Extra utilities and tools serving the mothership [rhiza](https://github.com/Jebel-Quant/rhiza).
 
-**📖 New to Rhiza? Check out the [Getting Started Guide](https://github.com/Jebel-Quant/rhiza-cli/blob/ad816ff3e91a8d6f07fcba979bc64576de3d0116/GETTING_STARTED.md) for a beginner-friendly introduction!**
+**📖 New to Rhiza? See the [mothership repository](https://github.com/Jebel-Quant/rhiza) for a beginner-friendly introduction to the ecosystem.**
 
-This package provides additional commands for the Rhiza ecosystem, such as version bumping, release management, and documentation helpers. It can be used as a plugin for `rhiza-cli` or as a standalone tool.
+This package provides additional commands for the Rhiza ecosystem, such as version bumping, release management, and documentation helpers. It is a standalone command-line tool: the Rhiza Makefile targets and CI invoke it via `uvx`, and you can run it directly the same way.
 
 ## Installation
 
-### As a Rhiza Plugin (Recommended)
+`rhiza-tools` is published to PyPI and runs as a standalone tool — no `rhiza-cli` install required.
 
-You can install `rhiza-tools` alongside `rhiza-cli` using `uvx` or `pip`. This automatically registers the tools as subcommands under `rhiza tools`.
-
-#### Using uvx (run without installation)
-
-```bash
-uvx "rhiza[tools]" tools --help
-```
-
-#### Using pip
-
-```bash
-pip install "rhiza[tools]"
-```
-
-### Standalone Usage
-
-You can also use `rhiza-tools` independently if you don't need the full `rhiza` CLI.
-
-#### Using uvx
+### Using uvx (run without installation)
 
 ```bash
 uvx rhiza-tools --help
 ```
 
-#### Using pip
+### Using pip
 
 ```bash
 pip install rhiza-tools
@@ -154,10 +136,6 @@ Update `README.md` with the current output from `make help`.
 **Usage:**
 
 ```bash
-# As plugin
-rhiza tools update-readme
-
-# Standalone
 rhiza-tools update-readme
 ```
 

--- a/src/rhiza_tools/__init__.py
+++ b/src/rhiza_tools/__init__.py
@@ -1,30 +1,29 @@
 """Rhiza Tools — Extra utilities and tools for the Rhiza ecosystem.
 
-Rhiza Tools provides additional commands and utilities that extend the capabilities
-of the main Rhiza CLI. It includes tools for version management, release automation,
-and documentation maintenance.
+Rhiza Tools provides additional commands and utilities for the Rhiza ecosystem.
+It includes tools for version management, release automation, and documentation
+maintenance.
 
 ## Key features
 
 - **Version Bumping**: Automate version updates in `pyproject.toml`.
 - **Release Management**: Streamline the release process with git tag automation.
 - **Documentation Helpers**: Keep your README up-to-date with CLI help output.
-- **Flexible Usage**: Use as a `rhiza` plugin or as a standalone CLI.
+- **Standalone CLI**: Run directly via `uvx rhiza-tools` — invoked by the Rhiza
+  Makefile targets and CI.
 
 ## Quick start
 
 Bump the project version:
 
 ```bash
-rhiza tools bump 1.0.1
-# or standalone
 rhiza-tools bump 1.0.1
 ```
 
 Create a release tag:
 
 ```bash
-rhiza tools release
+rhiza-tools release
 ```
 
 ## Main modules


### PR DESCRIPTION
Closes #326.

`rhiza-cli` is being retired. rhiza-tools is not actually consumed *through* rhiza-cli — every managed repo invokes it **standalone via `uvx rhiza-tools`** from its Makefile/CI. This PR removes the now-vestigial rhiza-cli plugin framing from the docs.

## Changes
- **README.md** — remove the "As a Rhiza Plugin (Recommended)" install section and the `uvx "rhiza[tools]"` / `rhiza tools <cmd>` examples; standalone `uvx`/`pip` is now the only documented interface. Repoint the getting-started link from the (retiring) rhiza-cli repo to the [rhiza mothership](https://github.com/Jebel-Quant/rhiza).
- **src/rhiza_tools/__init__.py** — drop "extend the capabilities of the main Rhiza CLI" and the `rhiza tools` plugin quick-start examples; describe the standalone CLI.
- **CLAUDE.md** — drop "via `rhiza-cli`" from the sync description.

## Scope
Docs/docstrings only — no behaviour change. The rhiza-cli-side removals (the `tools` extra, deptry entries, `rhiza tools` subcommand registration) live in the rhiza-cli repo and go away with its retirement. Removing the release commands themselves is tracked separately in #327; this PR intentionally leaves the command reference intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)