### PR TITLE
docs: reframe rhiza-tools as the CI/quality/security helper CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,15 @@ Guidance for Claude Code (and human contributors) working in this repository.
 
 ## What is this repo?
 
-`rhiza-tools` provides the release/versioning tooling used by Rhiza-managed
-projects — version bumping, release, rollback, the CI version matrix, and badge
-generation. Its own development infrastructure is synced from Rhiza.
+`rhiza-tools` is the shared **CI / quality / security helper CLI** for
+Rhiza-managed projects. It provides the CI Python-version matrix, benchmark
+analysis, tiered dependency auditing (`pip-audit`), and inline-suppression
+auditing — invoked via `uvx` from the Rhiza Makefile targets and reusable CI
+workflows. Its own development infrastructure is synced from Rhiza.
+
+> The release/versioning commands (`bump`, `release`, `rollback`,
+> `update-readme`) that once lived here have been removed; release orchestration
+> moved out of this package.
 
 ## Rhiza-managed files — do NOT edit directly
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![Downloads](https://static.pepy.tech/personalized-badge/rhiza-tools?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/rhiza-tools)
 [![CodeFactor](https://www.codefactor.io/repository/github/jebel-quant/rhiza-tools/badge)](https://www.codefactor.io/repository/github/jebel-quant/rhiza-tools)
 
-Extra utilities and tools serving the mothership [rhiza](https://github.com/Jebel-Quant/rhiza).
+The Rhiza ecosystem's shared CI / quality / security helper CLI, serving the mothership [rhiza](https://github.com/Jebel-Quant/rhiza).
 
 **📖 New to Rhiza? See the [mothership repository](https://github.com/Jebel-Quant/rhiza) for a beginner-friendly introduction to the ecosystem.**
 
-This package provides additional commands for the Rhiza ecosystem, such as the CI Python-version matrix, benchmark analysis, and dependency/suppression auditing. It is a standalone command-line tool: the Rhiza Makefile targets and CI invoke it via `uvx`, and you can run it directly the same way.
+rhiza-tools is the Rhiza ecosystem's shared **CI / quality / security helper CLI** — it provides the CI Python-version matrix, benchmark analysis, and dependency/suppression auditing. It is a standalone command-line tool: the Rhiza Makefile targets and CI invoke it via `uvx`, and you can run it directly the same way.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "rhiza-tools"
 version = "0.8.1"
-description = "Extra utilities and tools for the Rhiza ecosystem"
+description = "CI, quality, and security helper CLI for the Rhiza ecosystem"
 readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/src/rhiza_tools/__init__.py
+++ b/src/rhiza_tools/__init__.py
@@ -1,7 +1,7 @@
-"""Rhiza Tools — Extra utilities and tools for the Rhiza ecosystem.
+"""Rhiza Tools — CI, quality, and security helper CLI for the Rhiza ecosystem.
 
-Rhiza Tools provides additional commands and utilities for the Rhiza ecosystem.
-It includes tools for CI orchestration, benchmark analysis, and code hygiene
+Rhiza Tools is the shared helper CLI for Rhiza-managed projects. It provides the
+CI Python-version matrix, benchmark analysis, and dependency/suppression
 auditing.
 
 ## Key features

--- a/src/rhiza_tools/cli.py
+++ b/src/rhiza_tools/cli.py
@@ -30,7 +30,7 @@ def version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
-app = typer.Typer(help="Rhiza Tools - Extra utilities for Rhiza.")
+app = typer.Typer(help="Rhiza Tools — CI, quality, and security helper CLI for the Rhiza ecosystem.")
 
 # Shared option so --verbose / -v works both before and after the subcommand.
 VERBOSE_OPTION = typer.Option(False, "--verbose", "-v", help="Show verbose debug output.")
@@ -53,7 +53,7 @@ def main(
     ),
     verbose: bool = VERBOSE_OPTION,
 ) -> None:
-    """Rhiza Tools - Extra utilities for Rhiza."""
+    """Rhiza Tools — CI, quality, and security helper CLI for the Rhiza ecosystem."""
     configure_console(verbose=verbose)
 
 


### PR DESCRIPTION
## Summary

After removing the `bump` / `release` / `rollback` / `update-readme` commands (#333, #334, #335), the project still described itself as "release/versioning tooling." This updates the identity to what it actually is now: the Rhiza ecosystem's shared **CI / quality / security helper CLI** — `version-matrix`, `analyze-benchmarks`, `pip-audit`, and `suppression-audit`.

## Changes

- **`CLAUDE.md`** — rewrote "What is this repo?" (it literally listed the removed `bump`/`release`/`rollback` and non-existent badge generation), with a short note that release orchestration moved out.
- **`README.md`** — title tagline + intro paragraph.
- **`pyproject.toml`** — `description` (the PyPI one-liner).
- **`src/rhiza_tools/__init__.py`** and **`cli.py`** — package docstring, Typer app `--help`, and the callback docstring.

No behavior change — description/docs only.

## Verification

- `rhiza-tools --help` now shows: *"Rhiza Tools — CI, quality, and security helper CLI for the Rhiza ecosystem."*
- `uvx ruff check src/` clean; `uv run pytest tests/` — 111 passed.
- No `Extra utilities` / `release/versioning tooling` framing left (outside ADR history).

## Context

Follow-up to the discussion about rhiza-tools' role after the version-management removals. Related: cutover-sequencing hazard in jebel-quant/rhiza#1413, version-matrix source-of-truth in jebel-quant/rhiza#1412.

🤖 Generated with [Claude Code](https://claude.com/claude-code)