### PR TITLE
docs: drop stale pip-audit/suppression util refs from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,7 @@ snapshot:
 - `rhiza.mk`, `make.d/*.mk`, `requirements/*.txt`, `semgrep.yml`,
   `.cfg.toml`, `.env`, `.gitignore`, `.rhiza-version`
 - `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `assets/`, `completions/`
-- `tests/**` (the synced template test-suite), `utils/pip_audit_policy.py`,
-  `utils/suppression_audit.py`
+- `tests/**` (the synced template test-suite)
 - **Owned by you:** `.rhiza/template.yml` (and `.rhiza/template.lock`, which the
   tool regenerates).
 


### PR DESCRIPTION
## Summary

Prunes the last hand-editable pip-audit/suppression traces from `CLAUDE.md`. The Rhiza-managed-files inventory listed `.rhiza/utils/pip_audit_policy.py` and `.rhiza/utils/suppression_audit.py`, but those files no longer exist in this repo (removed upstream when the policies moved into rhiza-tools, and now the commands themselves are gone).

## Not touched (deliberately)

- **`SECURITY.md`** still claims `pip-audit` as a security measure, but it's **Rhiza-managed** (in `.rhiza/template.lock`) — editing it here would be clobbered on the next sync. Already fixed upstream in jebel-quant/rhiza#1415; it clears on the next `rhiza sync`.
- **`CLAUDE.md` "What is this repo?" note** intentionally records that the `pip-audit`/`suppression-audit` commands were removed — kept as accurate history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)